### PR TITLE
remove capitalization: import ... React

### DIFF
--- a/containers/payments/usePayment.js
+++ b/containers/payments/usePayment.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'React';
+import { useState, useEffect } from 'react';
 
 const usePayment = (submit) => {
     const [method, setMethod] = useState('');


### PR DESCRIPTION
In package.json (and everywhere else), the package name is react (no capitalization)