### PR TITLE
[Button] - Allow us to extend classNames

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -62,7 +62,7 @@ const Button = (props) => {
         <button
             role={role}
             disabled={loading ? true : disabled}
-            className={className}
+            className={'pm-button mr1 '.concat(className || '')}
             type={type}
             tabIndex={disabled ? '-1' : tabIndex}
             title={title}
@@ -98,7 +98,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-    className: 'pm-button mr1',
+    className: '',
     role: 'button',
     type: 'button',
     disabled: false,

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -62,7 +62,7 @@ const Button = (props) => {
         <button
             role={role}
             disabled={loading ? true : disabled}
-            className={'pm-button mr1 '.concat(className || '')}
+            className={'pm-button '.concat(className || '')}
             type={type}
             tabIndex={disabled ? '-1' : tabIndex}
             title={title}
@@ -98,7 +98,6 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-    className: '',
     role: 'button',
     type: 'button',
     disabled: false,


### PR DESCRIPTION
Today: 
`<Button className="mlauto">-></Button>` = :boom: no more styles :/

With the fix:
![Screenshot from 2019-03-22 12-31-52](https://user-images.githubusercontent.com/713283/54820150-7bf97300-4c9e-11e9-9d82-77e00cb8648c.png)

It works.
btw we should not have mr1 inside the button imho