### PR TITLE
Easier to extend classNames for the Icon

### DIFF
--- a/components/icon/Icon.js
+++ b/components/icon/Icon.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 const Icon = ({ name, className, viewBox, alt, ...rest }) => {
     return (
         <>
-            <svg viewBox={viewBox} className={className} role="img" focusable="false" {...rest}>
+            <svg viewBox={viewBox} className={`icon-16p `.concat(className)} role="img" focusable="false" {...rest}>
                 <use xlinkHref={`#shape-${name}`} />
             </svg>
             {alt ? <span className="sr-only">{alt}</span> : null}
@@ -30,7 +30,7 @@ Icon.propTypes = {
 
 Icon.defaultProps = {
     viewBox: '0 0 16 16',
-    className: 'icon-16p fill-global-grey'
+    className: ''
 };
 
 export default Icon;

--- a/components/icon/Icon.js
+++ b/components/icon/Icon.js
@@ -6,14 +6,23 @@ import PropTypes from 'prop-types';
  * <Icon name="label" alt="My label" />
  * @param {String} name of the svg icon present in the design-system
  * @param {String} className used on svg tag
+ * @param {String} fill      To construct the fill-global className
+ * @param {Number} size      To construct the icon size className icon-<size>p (default 16)
  * @param {String} viewBox
  * @param {String} alt used by screen reader
  * @return {React.Component}
  */
-const Icon = ({ name, className, viewBox, alt, ...rest }) => {
+const Icon = ({ name, className, viewBox, alt, fill, size, ...rest }) => {
+    const fillClass = fill ? `fill-global-${fill} ` : '';
     return (
         <>
-            <svg viewBox={viewBox} className={`icon-16p `.concat(className)} role="img" focusable="false" {...rest}>
+            <svg
+                viewBox={viewBox}
+                className={`icon-${size}p `.concat(fillClass, className).trim()}
+                role="img"
+                focusable="false"
+                {...rest}
+            >
                 <use xlinkHref={`#shape-${name}`} />
             </svg>
             {alt ? <span className="sr-only">{alt}</span> : null}
@@ -25,11 +34,15 @@ Icon.propTypes = {
     alt: PropTypes.string,
     name: PropTypes.string.isRequired,
     viewBox: PropTypes.string,
-    className: PropTypes.string
+    className: PropTypes.string,
+    fill: PropTypes.string,
+    size: PropTypes.number
 };
 
 Icon.defaultProps = {
     viewBox: '0 0 16 16',
+    size: 16,
+    fill: 'grey',
     className: ''
 };
 

--- a/components/toggle/Toggle.js
+++ b/components/toggle/Toggle.js
@@ -12,7 +12,7 @@ const label = (key) => {
 
     return (
         <span className="pm-toggle-label-text">
-            <Icon name={key} alt={I18N[key]} className="pm-toggle-label-img" />
+            <Icon name={key} alt={I18N[key]} fill="none" className="pm-toggle-label-img" />
         </span>
     );
 };


### PR DESCRIPTION
`<Icon className="ml1" />` didn't work.

![Screenshot from 2019-04-05 14-27-31](https://user-images.githubusercontent.com/713283/55627653-036ed800-57af-11e9-9c3a-56369997fa87.png)


New props:
- `fill`: default value **grey** -> fill color for the icon
- `size`: default value **16** -> size of the icon

