### PR TITLE
Improvements to ColorPicker

### DIFF
--- a/components/input/ColorPicker.js
+++ b/components/input/ColorPicker.js
@@ -26,7 +26,7 @@ const ColorPicker = ({ text, initialRgbaColor, onChange, ...rest }) => {
 
     useEffect(() => {
         setRgbaColor(initialRgbaColor);
-    }, [initialRgbaColor, rgbaColor]);
+    }, [initialRgbaColor]);
 
     const picker = (
         <div className="popover">

--- a/components/input/ColorPicker.js
+++ b/components/input/ColorPicker.js
@@ -4,7 +4,7 @@ import { Button } from 'react-components';
 import { ChromePicker } from 'react-color';
 import './ColorPicker.scss';
 
-const ColorPicker = ({ text, initialRgbaColor, onColorChange, ...rest }) => {
+const ColorPicker = ({ text, initialRgbaColor, onChange, ...rest }) => {
     const [display, setDisplay] = useState(false);
     const [rgbaColor, setRgbaColor] = useState(initialRgbaColor);
 
@@ -19,7 +19,14 @@ const ColorPicker = ({ text, initialRgbaColor, onColorChange, ...rest }) => {
     };
     const handleChange = (color) => {
         setRgbaColor(color.rgb);
+        if (onChange) {
+            onChange(color);
+        }
     };
+
+    useEffect(() => {
+        setRgbaColor(initialRgbaColor);
+    }, [initialRgbaColor, rgbaColor]);
 
     const picker = (
         <div className="popover">
@@ -27,12 +34,6 @@ const ColorPicker = ({ text, initialRgbaColor, onColorChange, ...rest }) => {
             <ChromePicker color={rgbaColor} onChange={handleChange} />
         </div>
     );
-
-    useEffect(() => {
-        if (onColorChange) {
-            onColorChange();
-        }
-    }, [rgbaColor]);
 
     return (
         <div className="relative">
@@ -47,7 +48,7 @@ const ColorPicker = ({ text, initialRgbaColor, onColorChange, ...rest }) => {
 ColorPicker.propTypes = {
     text: PropTypes.string,
     initialRgbaColor: PropTypes.object,
-    onColorChange: PropTypes.func
+    onChange: PropTypes.func
 };
 
 ColorPicker.defaultProps = {


### PR DESCRIPTION
Two new changes:
- I changed the prop name `onColorChange` to `onChange` since that is the common notation everywhere else. Also this prop is now passed down to `ChromePicker` so that we can control what happens with color changes from parent components.
- The `useEffect` hook is triggered by changes in the prop `initialRgbaColor`. In this way we can also change the color of the color picker from parent components.