### PR TITLE
Add animation when we close a modal

### DIFF
--- a/components/modal/useModal.js
+++ b/components/modal/useModal.js
@@ -8,13 +8,19 @@ const useModal = (initialState = false) => {
 
     const close = () => {
         const modal = document.querySelector('.pm-modalOverlay');
-        modal && modal.classList.add('pm-modalOverlay--fadeOut');
-        id = setTimeout(() => setModalState(false), 500);
+
+        if (modal) {
+            modal.classList.add('pm-modalOverlay--fadeOut');
+            id = setTimeout(() => setModalState(false), 500);
+            return;
+        }
+
+        setModalState(false);
     };
 
     useEffect(() => {
         return () => {
-            clearTimeout(id);
+            id && clearTimeout(id);
         };
     });
 

--- a/components/modal/useModal.js
+++ b/components/modal/useModal.js
@@ -1,10 +1,22 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 const useModal = (initialState = false) => {
     const [isOpen, setModalState] = useState(initialState);
-    const open = () => setModalState(true);
-    const close = () => setModalState(false);
     const toggle = () => setModalState(!isOpen);
+    const open = () => setModalState(true);
+    let id;
+
+    const close = () => {
+        const modal = document.querySelector('.pm-modalOverlay');
+        modal && modal.classList.add('pm-modalOverlay--fadeOut');
+        id = setTimeout(() => setModalState(false), 500);
+    };
+
+    useEffect(() => {
+        return () => {
+            clearTimeout(id);
+        };
+    });
 
     return {
         isOpen,


### PR DESCRIPTION
When closing the modal, the class `pm-modalOverlay--fadeOut` is added on `pm-modalOverlay`, let this animation execute itself before removing the code in the DOM (500ms duration).