### PR TITLE
Remove invalid translations for theme labels

### DIFF
--- a/containers/themes/ThemeCard.js
+++ b/containers/themes/ThemeCard.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { c } from 'ttag';
 import { RadioCard } from 'react-components';
 import { noop } from 'proton-shared/lib/helpers/function';
 
@@ -23,7 +22,7 @@ const ThemeCard = ({ label, id, alt, src, checked, onChange, disabled, customiza
 
     return (
         <RadioCard
-            label={c('Theme label').t`${label}`}
+            label={label}
             name="themeCard"
             id={id}
             checked={checked}

--- a/containers/themes/availableThemes.js
+++ b/containers/themes/availableThemes.js
@@ -1,4 +1,3 @@
-import { c } from 'ttag';
 import { THEMES } from 'proton-shared/lib/constants';
 import themeDarkSvg from 'design-system/assets/img/pm-images/theme-dark.svg';
 import themeLightSvg from 'design-system/assets/img/pm-images/theme-light.svg';
@@ -14,7 +13,7 @@ const {
 } = THEMES;
 
 const themeDark = {
-    label: c('Theme label').t`${darkLabel}`,
+    label: darkLabel,
     id: darkId,
     alt: stripThemeIdentifier(darkId),
     src: themeDarkSvg,
@@ -22,7 +21,7 @@ const themeDark = {
 };
 
 const themeLight = {
-    label: c('Theme label').t`${lightLabel}`,
+    label: lightLabel,
     id: lightId,
     alt: stripThemeIdentifier(lightId),
     src: themeLightSvg,
@@ -30,7 +29,7 @@ const themeLight = {
 };
 
 const themeBlue = {
-    label: c('Theme label').t`${blueLabel}`,
+    label: blueLabel,
     id: blueId,
     alt: stripThemeIdentifier(blueId),
     src: themeBlueSvg,
@@ -38,7 +37,7 @@ const themeBlue = {
 };
 
 const themeCustom = {
-    label: c('Theme label').t`${customLabel}`,
+    label: customLabel,
     id: customId,
     alt: stripThemeIdentifier(customId),
     src: themeTestSvg,


### PR DESCRIPTION
https://ttag.js.org/docs/tag-gettext.html#invalid

Moved translation of theme labels into proton-shared.

Related PR in `proton-shared`: https://github.com/ProtonMail/proton-shared/pull/18