### PR TITLE
Fix/typos

### DIFF
--- a/containers/apps/ProtonMailBetaSection.js
+++ b/containers/apps/ProtonMailBetaSection.js
@@ -7,7 +7,7 @@ const ProtonMailBetaSection = () => {
         <>
             <SubTitle>ProtonMail Beta</SubTitle>
             <Alert learnMore="https://protonmail.com/blog/how-to-become-protonmail-beta-tester/">{c('Info')
-                .t`Participating to beta programs gives you the opportunity to test new features and improvements beforee they get released to the general public. It offers a chance to have an active role in shaping the quality of our services`}</Alert>
+                .t`Participating in beta programs gives you the opportunity to test new features and improvements before they get released to the general public. It offers a chance to have an active role in shaping the quality of our services.`}</Alert>
         </>
     );
 };

--- a/containers/apps/ProtonMailBridgeSection.js
+++ b/containers/apps/ProtonMailBridgeSection.js
@@ -9,7 +9,7 @@ const ProtonMailBridgeSection = () => {
         <>
             <SubTitle>ProtonMail Bridge</SubTitle>
             <Alert learnMore="https://protonmail.com/bridge/">{c('Info')
-                .t`ProtonMail Supports IMAP/SMTP via the ProtonMail Bridge application. Thunderbird, Microsoft Outlook, and Apple Mail are officially supported on both Windows and MacOS.`}</Alert>
+                .t`ProtonMail supports IMAP/SMTP via the ProtonMail Bridge application. Thunderbird, Microsoft Outlook, and Apple Mail are officially supported on both Windows and MacOS.`}</Alert>
             {hasPaidMail ? null : (
                 <Link to="/settings/subscription" className="pm-button pm-button--primary">{c('Action')
                     .t`Upgrade`}</Link>

--- a/containers/apps/ProtonVPNAppsSection.js
+++ b/containers/apps/ProtonVPNAppsSection.js
@@ -13,7 +13,7 @@ const ProtonVPNAppsSection = () => {
                     .t`Download page`}</Href>
             </Block>
             <Alert learnMore="https://protonvpn.com/support/vpn-login/">{c('Info')
-                .t`To connect to ProtonVPN with third party clients (e.g. Tunnelblick on MacOS or OpenVPN on GNU/Linux), you need specific credentials. to get these credentials, go to the Account settings when logged in at ProtonVPN.`}</Alert>
+                .t`To connect to ProtonVPN with third-party clients (e.g. Tunnelblick on MacOS or OpenVPN on GNU/Linux), you need specific credentials. to get these credentials, go to the Account settings when logged in at ProtonVPN.`}</Alert>
             <Block>
                 <Href url="https://account.protonvpn.com" className="pm-button pm-button--primary">{c('Link')
                     .t`ProtonVPN login`}</Href>

--- a/containers/autoReply/AutoReplyForm/AutoReplyForm.js
+++ b/containers/autoReply/AutoReplyForm/AutoReplyForm.js
@@ -20,7 +20,7 @@ const AutoReplyForm = ({ model, updateModel }) => {
         return (
             <>
                 <DurationField value={model.duration} onChange={updateModel('duration')} />
-                <Alert>{c('Info').t`Auto-reply is active from the start time to the end time`}</Alert>
+                <Alert>{c('Info').t`Auto-reply is active from the start time to the end time.`}</Alert>
                 <StartDateField value={model.startDate} onChange={updateModel('startDate')} />
                 <StartTimeField value={model.startTime} onChange={updateModel('startTime')} />
                 <EndDateField value={model.endDate} onChange={updateModel('endDate')} />

--- a/containers/domains/DKIMSection.js
+++ b/containers/domains/DKIMSection.js
@@ -25,7 +25,7 @@ const DKIMSection = ({ domain }) => {
                 </TableBody>
             </Table>
             <Alert type="warning">{c('Info')
-                .t`Keep this record in your DNS for as long as you want to use DKIM. You can change its Value to <code>off</code> to disable DKIM`}</Alert>
+                .t`Keep this record in your DNS for as long as you want to use DKIM. You can change its Value to <code>off</code> to disable DKIM.`}</Alert>
         </>
     );
 };

--- a/containers/domains/DomainsSection.js
+++ b/containers/domains/DomainsSection.js
@@ -37,7 +37,7 @@ const DomainsSection = () => {
                 <PrimaryButton onClick={open} className="mr1">{c('Action').t`Add domain`}</PrimaryButton>
                 <Button disabled={loading} onClick={call}>{c('Action').t`Refresh status`}</Button>
             </Block>
-            {!loading && !domains.length ? <Alert>{c('Info').t`No domains yet`}</Alert> : null}
+            {!loading && !domains.length ? <Alert>{c('Info').t`No domains yet.`}</Alert> : null}
             {loading ? null : <DomainsTable domains={domains} />}
             <Block>
                 {UsedDomains} / {MaxDomains} {c('Info').t`domains used`}

--- a/containers/general/ShortcutsModal.js
+++ b/containers/general/ShortcutsModal.js
@@ -177,7 +177,7 @@ const ShortcutsModal = (props) => {
                 <Summary className="bold h3">{c('Title').t`Contacts`}</Summary>
                 <div className="flex-autogrid onmobile-flex-column">
                     <div className="flex-autogrid-item">
-                        <Legend className="bold">{c('Title').t`Contact List`}</Legend>
+                        <Legend className="bold">{c('Title').t`Contact list`}</Legend>
                         <ul className="unstyled">
                             <li>
                                 <kbd>↑</kbd> + <kbd>↓</kbd> <strong>Moving</strong> between contacts.
@@ -192,7 +192,7 @@ const ShortcutsModal = (props) => {
                     </div>
 
                     <div className="flex-autogrid-item">
-                        <Legend className="bold">{c('Title').t`Contact Details`}</Legend>
+                        <Legend className="bold">{c('Title').t`Contact details`}</Legend>
                         <ul className="unstyled">
                             <li>
                                 <kbd>←</kbd> <strong>Exits</strong> contact details.

--- a/containers/general/ShortcutsModal.js
+++ b/containers/general/ShortcutsModal.js
@@ -174,7 +174,7 @@ const ShortcutsModal = (props) => {
                 </div>
             </Details>
             <Details className="bordered-container mb1">
-                <Summary className="bold h3">{c('Title').t`Contact`}</Summary>
+                <Summary className="bold h3">{c('Title').t`Contacts`}</Summary>
                 <div className="flex-autogrid onmobile-flex-column">
                     <div className="flex-autogrid-item">
                         <Legend className="bold">{c('Title').t`Contact List`}</Legend>

--- a/containers/keys/AddressKeysHeader.js
+++ b/containers/keys/AddressKeysHeader.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { SubTitle, Alert, Block, PrimaryButton, Button } from 'react-components';
 
 const AddressKeysHeader = ({ handleAddKey, handleImportKey, handleReactivateKeys }) => {
-    const title = c('Title').t`Email Encryption Keys`;
+    const title = c('Title').t`Email encryption keys`;
 
     return (
         <>

--- a/containers/keys/ContactKeysHeader.js
+++ b/containers/keys/ContactKeysHeader.js
@@ -3,7 +3,7 @@ import { c } from 'ttag';
 import { SubTitle, Alert } from 'react-components';
 
 const ContactKeysHeader = () => {
-    const title = c('Title').t`Contact Encryption Keys`;
+    const title = c('Title').t`Contact encryption keys`;
 
     return (
         <>

--- a/containers/layouts/DraftTypeSelect.js
+++ b/containers/layouts/DraftTypeSelect.js
@@ -9,7 +9,7 @@ const { NORMAL, PLAIN_TEXT } = DRAFT_TYPE;
 const DraftTypeSelect = ({ draftType, onChange, loading }) => {
     const options = [
         { text: c('Option').t`Normal`, value: NORMAL },
-        { text: c('Option').t`Plain Text`, value: PLAIN_TEXT }
+        { text: c('Option').t`Plain text`, value: PLAIN_TEXT }
     ];
 
     const handleChange = ({ target }) => onChange(target.value);

--- a/containers/layouts/LayoutsSection.js
+++ b/containers/layouts/LayoutsSection.js
@@ -122,7 +122,7 @@ const LayoutsSection = () => {
                     <span className="mr1">{c('Label').t`Conversations`}</span>
                     <Info
                         title={c('Tooltip')
-                            .t`Conversation Grouping automatically groups messages in the same conversation together.`}
+                            .t`Conversation grouping automatically groups messages in the same conversation together.`}
                     />
                 </Label>
                 <ViewModeRadios
@@ -152,7 +152,7 @@ const LayoutsSection = () => {
                 </Row>
             ) : null}
             <Row>
-                <Label htmlFor="draftType">{c('Label').t`Composer Mode`}</Label>
+                <Label htmlFor="draftType">{c('Label').t`Composer mode`}</Label>
                 <Field>
                     <DraftTypeSelect
                         id="draftTypeSelect"
@@ -163,7 +163,7 @@ const LayoutsSection = () => {
                 </Field>
             </Row>
             <Row>
-                <Label htmlFor="textDirection">{c('Label').t`Composer Text Direction`}</Label>
+                <Label htmlFor="textDirection">{c('Label').t`Composer text direction`}</Label>
                 <Field>
                     <TextDirectionSelect
                         id="textDirection"

--- a/containers/logs/LogsSection.js
+++ b/containers/logs/LogsSection.js
@@ -102,7 +102,7 @@ const LogsSection = () => {
 
     return (
         <>
-            <SubTitle>{c('Title').t`Authentication Logs`}</SubTitle>
+            <SubTitle>{c('Title').t`Authentication logs`}</SubTitle>
             <Alert>{c('Info')
                 .t`Logs includes authentication attempts for all Proton services that use your Proton credentials.`}</Alert>
             <Block className="flex flex-spacebetween">

--- a/containers/logs/LogsTable.js
+++ b/containers/logs/LogsTable.js
@@ -32,7 +32,7 @@ const LogsTable = ({ logs, logAuth, loading }) => {
     }
 
     if (!loading && !logs.length) {
-        return <Alert>{c('Info').t`No logs yet`}</Alert>;
+        return <Alert>{c('Info').t`No logs yet.`}</Alert>;
     }
 
     return (

--- a/containers/members/MemberModal.js
+++ b/containers/members/MemberModal.js
@@ -95,7 +95,7 @@ const MemberModal = ({ onClose, organization, domains, ...rest }) => {
                         value={model.confirm}
                         className="flex-autogrid-item"
                         onChange={handleChange('confirm')}
-                        placeholder={c('Placeholder').t`Confirm Password`}
+                        placeholder={c('Placeholder').t`Confirm password`}
                         required
                     />
                 </Field>

--- a/containers/members/MembersSection.js
+++ b/containers/members/MembersSection.js
@@ -100,7 +100,7 @@ const MembersSection = () => {
             </Table>
             <Alert>
                 <span className="mr1">{c('Info').t`You can add and manage addresses for the user in your`}</span>
-                <Link to="/settings/addresses">{c('Link').t`Address Settings`}</Link>
+                <Link to="/settings/addresses">{c('Link').t`Address settings`}</Link>
             </Alert>
         </>
     );

--- a/containers/notification/DesktopNotificationPanel.js
+++ b/containers/notification/DesktopNotificationPanel.js
@@ -9,7 +9,7 @@ const DesktopNotificationPanel = () => {
     const test = () => {
         if (status) {
             Push.create(c('Info').t`You have a new email`, {
-                body: 'Quarterly Operations Update - Q1 2016 ',
+                body: 'Quarterly operations update - Q1 2016 ',
                 icon: '/assets/img/notification-badge.gif',
                 onClick() {
                     window.focus();

--- a/containers/payments/Bitcoin.js
+++ b/containers/payments/Bitcoin.js
@@ -45,7 +45,7 @@ const Bitcoin = ({ amount, currency, type }) => {
                     .t`Bitcoin transactions can take some time to be confirmed (up to 24 hours). Once confirmed, we will add credits to your account. After transaction confirmation, you can pay your invoice with the credits.`}</Alert>
             ) : (
                 <Alert learnMore="https://protonmail.com/support/knowledge-base/paying-with-bitcoin">{c('Info')
-                    .t`After making your Bitcoin payment, please follow the instructions below to upgrade`}</Alert>
+                    .t`After making your Bitcoin payment, please follow the instructions below to upgrade.`}</Alert>
             )}
         </>
     );

--- a/containers/payments/PlansSection.js
+++ b/containers/payments/PlansSection.js
@@ -261,7 +261,7 @@ const PlansSection = () => {
                                     <td className="bg-global-muted">{c('Header').t`Additional features`}</td>
                                     <td className="aligncenter">{c('Plan option').t`Only basic email features`}</td>
                                     <td className="aligncenter">{c('Plan option')
-                                        .t`Folders, Labels, Filters, Encrypted Contacts, Auto-responder and more`}</td>
+                                        .t`Folders, Labels, Filters, Encrypted contacts, Auto-responder and more`}</td>
                                     <td className="aligncenter">{c('Plan option')
                                         .t`All Plus features, and catch-all email, multi-user support and more`}</td>
                                     <td className="aligncenter">{c('Plan option')

--- a/containers/payments/subscription/CyclePromotion.js
+++ b/containers/payments/subscription/CyclePromotion.js
@@ -17,10 +17,10 @@ const CyclePromotion = ({ model, onChange }) => {
                 </Alert>
             )}
             {model.cycle === YEARLY && (
-                <Alert>{c('Info').t`A 20% discount for annual billing has been automatically applied`}</Alert>
+                <Alert>{c('Info').t`A 20% discount for annual billing has been automatically applied.`}</Alert>
             )}
             {model.cycle === TWO_YEARS && (
-                <Alert>{c('Info').t`A 33% discount two year billing has been automatically applied`}</Alert>
+                <Alert>{c('Info').t`A 33% discount two year billing has been automatically applied.`}</Alert>
             )}
         </>
     );

--- a/containers/sessions/SessionsSection.js
+++ b/containers/sessions/SessionsSection.js
@@ -29,7 +29,7 @@ const CLIENTS = {
     WebSettings: c('Badge').t`ProtonMail settings for web`,
     iOS: c('Badge').t`ProtonMail for iOS`,
     Android: c('Badge').t`ProtonMail for Android`,
-    ImportExport: c('Badge').t`ProtonMail Import-Export`,
+    ImportExport: c('Badge').t`ProtonMail import-export`,
     Bridge: c('Badge').t`ProtonMail Bridge`,
     WebVPN: c('Badge').t`ProtonVPN for web`,
     VPN: c('Badge').t`ProtonVPN for Windows`,

--- a/containers/themes/CustomThemeModal.js
+++ b/containers/themes/CustomThemeModal.js
@@ -20,7 +20,7 @@ const CustomThemeModal = ({ onClose, onSave, theme: initialTheme = '', ...rest }
             {...rest}
         >
             <Alert type="warning">{c('Warning')
-                .t`Custom themes from third parties can potentially betray your privacy. Only use themes from trusted sources`}</Alert>
+                .t`Custom themes from third parties can potentially betray your privacy. Only use themes from trusted sources.`}</Alert>
             <Label className="mb1" htmlFor="themeTextarea">{c('Label').t`CSS code`}</Label>
             <TextArea
                 className="mb1"

--- a/containers/themes/ThemesSection.js
+++ b/containers/themes/ThemesSection.js
@@ -53,9 +53,9 @@ const ThemesSection = () => {
         <>
             <SubTitle>{c('Title').t`Themes`}</SubTitle>
             <Alert>{c('Info')
-                .t`ProtonMail offers 3 default themes to select from. You can also import a custom theme using our CSS editor`}</Alert>
+                .t`ProtonMail offers 3 default themes to select from. You can also import a custom theme using our CSS editor.`}</Alert>
             <Alert type="warning">{c('Info')
-                .t`Selecting another theme will override your current theme and any customization will be lost`}</Alert>
+                .t`Selecting another theme will override your current theme and any customization will be lost.`}</Alert>
             <ThemeCards
                 list={availableThemes}
                 themeId={themeId}


### PR DESCRIPTION
* All alerts are punctuated at the end now.
* Typos here and there corrected (very few, e.g. OopenVPN instead of OpenVPN)
* Remove multiple capitalization in titles (e.g. Authentication logs instead of Authentication Logs)