### PR TITLE
Add ability to bind onChange to autocomplete hook

### DIFF
--- a/components/autocomplete/useAutocomplete.js
+++ b/components/autocomplete/useAutocomplete.js
@@ -1,15 +1,28 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { noop } from 'proton-shared/lib/helpers/function';
 
-const defaultItemToLabel = (label) => label;
+const defaultLabelToItem = (label) => label;
 
 const useAutocomplete = ({
     multiple = true,
     initialSelectedItems = [],
     initialInputValue = '',
-    labelToItem = defaultItemToLabel
+    labelToItem = defaultLabelToItem,
+    onChange = noop
 } = {}) => {
+    const [initialized, setInitialized] = useState(false);
     const [selectedItems, setSelectedItems] = useState(initialSelectedItems);
     const [inputValue, changeInputValue] = useState(initialInputValue);
+
+    // We want to emit onChange when items are selected or removed,
+    // but not with the initial values on mount
+    useEffect(() => {
+        if (initialized) {
+            onChange(selectedItems);
+        } else {
+            setInitialized(true);
+        }
+    }, [selectedItems]);
 
     const select = (item, label) => {
         changeInputValue(multiple ? '' : label);

--- a/components/autocomplete/useAutocomplete.js
+++ b/components/autocomplete/useAutocomplete.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { noop, identity } from 'proton-shared/lib/helpers/function';
 
 const useAutocomplete = ({
@@ -8,17 +8,17 @@ const useAutocomplete = ({
     labelToItem = identity,
     onChange = noop
 } = {}) => {
-    const [initialized, setInitialized] = useState(false);
+    const initializedRef = useRef(false);
     const [selectedItems, setSelectedItems] = useState(initialSelectedItems);
     const [inputValue, changeInputValue] = useState(initialInputValue);
 
     // We want to emit onChange when items are selected or removed,
     // but not with the initial values on mount
     useEffect(() => {
-        if (initialized) {
+        if (initializedRef.current) {
             onChange(selectedItems);
         } else {
-            setInitialized(true);
+            initializedRef.current = true;
         }
     }, [selectedItems]);
 

--- a/components/autocomplete/useAutocomplete.js
+++ b/components/autocomplete/useAutocomplete.js
@@ -1,13 +1,11 @@
 import { useState, useEffect } from 'react';
-import { noop } from 'proton-shared/lib/helpers/function';
-
-const defaultLabelToItem = (label) => label;
+import { noop, identity } from 'proton-shared/lib/helpers/function';
 
 const useAutocomplete = ({
     multiple = true,
     initialSelectedItems = [],
     initialInputValue = '',
-    labelToItem = defaultLabelToItem,
+    labelToItem = identity,
     onChange = noop
 } = {}) => {
     const [initialized, setInitialized] = useState(false);

--- a/components/autocomplete/useAutocomplete.test.js
+++ b/components/autocomplete/useAutocomplete.test.js
@@ -55,7 +55,8 @@ describe('useAutocomplete hook', () => {
                 onChange: onChangeSpy
             })
         );
+        expect(onChangeSpy).toHaveBeenCalledTimes(0);
         act(() => result.current.select(newItem, newItem.label));
-        expect(onChangeSpy).toBeCalledWith([...initialSelectedItems, newItem]);
+        expect(onChangeSpy).toHaveBeenCalledWith([...initialSelectedItems, newItem]);
     });
 });

--- a/components/autocomplete/useAutocomplete.test.js
+++ b/components/autocomplete/useAutocomplete.test.js
@@ -43,4 +43,19 @@ describe('useAutocomplete hook', () => {
         expect(result.current.selectedItems).toEqual([newItem]);
         expect(result.current.inputValue).toBe(newItem.label);
     });
+
+    it('should emit onChange when item is added into the list', () => {
+        const onChangeSpy = jest.fn();
+        const newItem = { label: 'test2', value: 'T2' };
+        const initialSelectedItems = [{ label: 'test', value: 'T' }];
+        const { result } = renderHook(() =>
+            useAutocomplete({
+                multiple: true,
+                initialSelectedItems,
+                onChange: onChangeSpy
+            })
+        );
+        act(() => result.current.select(newItem, newItem.label));
+        expect(onChangeSpy).toBeCalledWith([...initialSelectedItems, newItem]);
+    });
 });


### PR DESCRIPTION
proton-shared PR for identity function: https://github.com/ProtonMail/proton-shared/pull/24

Initial idea was that if you wanted to keep track of selected/removed events in components using autocomplete hook, you would just create custom functions like:

```
const handleSelect = (item, label) => {
  select(item, label);
  // your stuff
}
```

But this way you don't yet have access to updated selectedItems list, because it's going to be updated after the next render/state update, so you'd end upt needing to reimplement the whole select function from hook. Solved this by adding an effect, that will call onChange after selectedItems changes.

```
const {...} = useAutocomplete({
  onChange: (selectedItems) => {
    // your stuff using updated selectedItems
  }
})
```