### PR TITLE
Fix i18n errors

### DIFF
--- a/containers/addresses/AddressesSection.js
+++ b/containers/addresses/AddressesSection.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { c } from 'ttag';
+import { c, msgid } from 'ttag';
 import { Block, Loader, SubTitle, useOrganization, useMembers } from 'react-components';
 
 import AddressesToolbar from './AddressesToolbar';
@@ -37,7 +37,7 @@ const AddressesSection = () => {
             {MaxAddresses > 1 ? (
                 <Block className="opacity-50">
                     {UsedAddresses} / {MaxAddresses}{' '}
-                    {c('Info').ngettext('address used', 'addresses used', UsedAddresses)}
+                    {c('Info').ngettext(msgid`address used`, `addresses used`, UsedAddresses)}
                 </Block>
             ) : null}
         </>

--- a/containers/domains/DomainsSection.js
+++ b/containers/domains/DomainsSection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { c } from 'ttag';
+import { c, msgid } from 'ttag';
 import {
     useEventManager,
     useOrganization,
@@ -37,7 +37,7 @@ const DomainsSection = () => {
             {!loading && !domains.length ? <Alert>{c('Info').t`No domains yet.`}</Alert> : null}
             {loading ? null : <DomainsTable domains={domains} />}
             <Block className="opacity-50">
-                {UsedDomains} / {MaxDomains} {c('Info').ngettext('domain used', 'domains used', UsedDomains)}
+                {UsedDomains} / {MaxDomains} {c('Info').ngettext(msgid`domain used`, `domains used`, UsedDomains)}
             </Block>
         </>
     );

--- a/containers/members/MembersSection.js
+++ b/containers/members/MembersSection.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { c } from 'ttag';
+import { c, msgid } from 'ttag';
 import {
     Table,
     TableHeader,
@@ -102,7 +102,7 @@ const MembersSection = () => {
             </Table>
             <Block className="opacity-50">
                 {organization.UsedMembers} / {organization.MaxMembers}{' '}
-                {c('Info').ngettext('member used', 'members used', organization.UsedMembers)}
+                {c('Info').ngettext(msgid`member used`, `members used`, organization.UsedMembers)}
             </Block>
             <Alert>
                 <span className="mr0-5">{c('Info').t`You can add and manage addresses for the user in your`}</span>

--- a/containers/payments/subscription/helpers.js
+++ b/containers/payments/subscription/helpers.js
@@ -1,6 +1,6 @@
 import { PLAN_SERVICES, PLAN_TYPES } from 'proton-shared/lib/constants';
 import { hasBit } from 'proton-shared/lib/helpers/bitset';
-import { c, ngettext, msgid } from 'ttag';
+import { c, msgid } from 'ttag';
 import { isEquivalent } from 'proton-shared/lib/helpers/object';
 
 const { PLAN, ADDON } = PLAN_TYPES;
@@ -9,19 +9,19 @@ const { MAIL, VPN } = PLAN_SERVICES;
 const I18N = {
     included: c('Option').t`included`,
     address(value) {
-        return ngettext(msgid`1 address`, `${value} addresses`, value);
+        return c('Option').ngettext(msgid`1 address`, `${value} addresses`, value);
     },
     space(value) {
-        return ngettext(msgid`1 GB storage`, `${value} GB storage`, value);
+        return c('Option').ngettext(msgid`1 GB storage`, `${value} GB storage`, value);
     },
     domain(value) {
-        return ngettext(msgid`1 custom domain`, `${value} custom domains`, value);
+        return c('Option').ngettext(msgid`1 custom domain`, `${value} custom domains`, value);
     },
     member(value) {
-        return ngettext(msgid`1 user`, `${value} users`, value);
+        return c('Option').ngettext(msgid`1 user`, `${value} users`, value);
     },
     vpn(value) {
-        return ngettext(msgid`1 VPN connection`, `${value} VPN connections`, value);
+        return c('Option').ngettext(msgid`1 VPN connection`, `${value} VPN connections`, value);
     }
 };
 


### PR DESCRIPTION
Fixes several errors:

- plurals need `msgid` as as a first parameter: https://c-3po.js.org/reference-ngettext.html#usage
- nggettext throws errors when string parameters are not template literals, so fixed that
- added missing contexts