### PR TITLE
Fix keyboard focus for modals and buttons

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -33,7 +33,9 @@ const Button = ({
         }
 
         if (event.target === event.currentTarget && (key === 'space' || key === 'enter')) {
-            event.preventDefault();
+            if (!['reset', 'submit'].includes(event.target.type)) {
+                event.preventDefault();
+            }
 
             if (onClick) {
                 onClick(event);

--- a/components/modal/Confirm.js
+++ b/components/modal/Confirm.js
@@ -13,6 +13,7 @@ const Confirm = ({ title, onClose, onConfirm, children, cancel, confirm, ...rest
             }}
             title={title}
             close={cancel}
+            autoFocusClose={true}
             submit={confirm}
             small
             {...rest}

--- a/components/modal/FormModal.js
+++ b/components/modal/FormModal.js
@@ -20,6 +20,7 @@ const Modal = ({
     loading,
     children,
     modalTitleID,
+    autoFocusClose,
     footer,
     hasClose,
     noValidate,
@@ -51,7 +52,13 @@ function DemoModal({ onAdd, ...rest }) {
 
         return (
             <FooterModal>
-                {typeof close === 'string' ? <ResetButton disabled={loading}>{close}</ResetButton> : close}
+                {typeof close === 'string' ? (
+                    <ResetButton autoFocus={autoFocusClose} disabled={loading}>
+                        {close}
+                    </ResetButton>
+                ) : (
+                    close
+                )}
                 {typeof submit === 'string' ? (
                     <PrimaryButton loading={loading} type="submit">
                         {submit}
@@ -89,6 +96,7 @@ Modal.propTypes = {
     submit: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     close: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     noValidate: PropTypes.bool,
+    autoFocusClose: PropTypes.bool,
     small: PropTypes.bool,
     background: PropTypes.bool,
     hasClose: PropTypes.bool
@@ -101,6 +109,7 @@ Modal.defaultProps = {
     isBehind: false,
     isClosing: false,
     noValidate: false,
+    autoFocusClose: false,
     hasClose: true,
     modalTitleID: 'modalTitle'
 };

--- a/containers/general/ShortcutsModal.js
+++ b/containers/general/ShortcutsModal.js
@@ -7,7 +7,12 @@ import { FormModal, Details, Summary, Legend } from 'react-components';
 const ShortcutsModal = (props) => {
     const IS_MAC = isMac();
     return (
-        <FormModal title={c('Title').t`Keyboard shortcuts`} close={c('Action').t`Close`} {...props}>
+        <FormModal
+            autoFocusClose={true}
+            title={c('Title').t`Keyboard shortcuts`}
+            close={c('Action').t`Close`}
+            {...props}
+        >
             <Details className="bordered-container mb1" open={true}>
                 <Summary className="bold h3">{c('Title').t`General`}</Summary>
                 <div className="flex-autogrid onmobile-flex-column">

--- a/containers/labels/NewLabelForm.js
+++ b/containers/labels/NewLabelForm.js
@@ -15,6 +15,7 @@ function NewLabelForm({ label, onChangeColor, onChangeName }) {
                     value={label.Name}
                     onChange={onChangeName}
                     placeholder={c('New Label form').t`Name`}
+                    autoFocus
                     required
                 />
             </Row>


### PR DESCRIPTION
Most of the time when we open a modal the autofocus is not there. So we can't access to the  modal via the keyboard.
Also buttons inside the modals were broken with the keyboard.

- Add prop autoFocusClose (_default false_ to autofocus on the close button -> ex confirmModal, keyboard modal)
- Allow keyboard on enter/space for button type=reset|submit
- Autofocus Name input for the label modal


> _Why keep the preventDefault on button ?_

Because if you remove it, when you open a modal with `autoFocusClose=true` it will auto-close the modal (╯°□°）╯︵ ┻━┻ 
---> There should be a better way.

Anyway, we need to fix the focus in every modals


- [ ] tests