### PR TITLE
Add missing invoice types and fix input warnings

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -4,9 +4,10 @@ import PropTypes from 'prop-types';
 import { generateUID } from '../../helpers/component';
 import useInput from './useInput';
 import ErrorZone from '../text/ErrorZone';
+import { omit } from 'proton-shared/lib/helpers/object';
 
 const Input = React.forwardRef((props, ref) => {
-    const { className, error, ...rest } = props;
+    const { className, error, ...rest } = omit(props, ['onPressEnter']);
     const { handlers, statusClasses, status } = useInput(props);
     const [uid] = useState(generateUID('input'));
     return (
@@ -31,7 +32,6 @@ Input.propTypes = {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     id: PropTypes.string,
-    inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     name: PropTypes.string,
     onBlur: PropTypes.func,
     onChange: PropTypes.func,

--- a/containers/invoices/InvoiceState.js
+++ b/containers/invoices/InvoiceState.js
@@ -8,14 +8,16 @@ const TYPES = {
     [INVOICE_STATE.UNPAID]: 'error',
     [INVOICE_STATE.PAID]: 'success',
     [INVOICE_STATE.VOID]: 'default',
-    [INVOICE_STATE.BILLED]: 'default'
+    [INVOICE_STATE.BILLED]: 'default',
+    [INVOICE_STATE.WRITEOFF]: 'default'
 };
 
 const getStatesI18N = () => ({
     [INVOICE_STATE.UNPAID]: c('Invoice state display as badge').t`Unpaid`,
     [INVOICE_STATE.PAID]: c('Invoice state display as badge').t`Paid`,
     [INVOICE_STATE.VOID]: c('Invoice state display as badge').t`Void`,
-    [INVOICE_STATE.BILLED]: c('Invoice state display as badge').t`Billed`
+    [INVOICE_STATE.BILLED]: c('Invoice state display as badge').t`Billed`,
+    [INVOICE_STATE.WRITEOFF]: c('Invoice state display as badge').t`Writeoff`
 });
 
 const InvoiceState = ({ invoice }) => {

--- a/containers/invoices/InvoiceType.js
+++ b/containers/invoices/InvoiceType.js
@@ -8,7 +8,12 @@ const InvoiceType = ({ invoice }) => {
         [INVOICE_TYPE.SUBSCRIPTION]: c('Invoice type display as badge').t`Subscription`,
         [INVOICE_TYPE.CANCELLATION]: c('Invoice type display as badge').t`Cancellation`,
         [INVOICE_TYPE.CREDIT]: c('Invoice type display as badge').t`Credit`,
-        [INVOICE_TYPE.DONATION]: c('Invoice type display as badge').t`Donation`
+        [INVOICE_TYPE.DONATION]: c('Invoice type display as badge').t`Donation`,
+        [INVOICE_TYPE.CHARGEBACK]: c('Invoice type display as badge').t`Chargeback`,
+        [INVOICE_TYPE.RENEWAL]: c('Invoice type display as badge').t`Renewal`,
+        [INVOICE_TYPE.REFUND]: c('Invoice type display as badge').t`Refund`,
+        [INVOICE_TYPE.MODIFICATION]: c('Invoice type display as badge').t`Modification`,
+        [INVOICE_TYPE.ADDITION]: c('Invoice type display as badge').t`Addition`
     };
 
     return TYPES[invoice.Type];


### PR DESCRIPTION
Backend model has more invoice types and states than we have defined: https://gitlab.protontech.ch/ProtonMail/Slim-API/blob/develop/app/Models/Invoice.php

Related PR: https://github.com/ProtonMail/proton-shared/pull/27

Also input component forwarded some unexpected properties to the element which threw warnings in console.