### PR TITLE
Ignore null from dropdown menu children and fix login input widths

### DIFF
--- a/components/dropdown/DropdownMenu.js
+++ b/components/dropdown/DropdownMenu.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const DropdownMenu = ({ children, className }) => {
     return (
         <ul className={`unstyled mt0-5 mb0-5 ${className}`}>
-            {React.Children.map(children, (child) => {
+            {React.Children.toArray(children).map((child) => {
                 return (
                     <li className={`dropDown-item`} key={child.key}>
                         {child}

--- a/containers/login/LoginForm.js
+++ b/containers/login/LoginForm.js
@@ -20,38 +20,38 @@ const LoginForm = ({ onSubmit, loading }) => {
 
     return (
         <form name="loginForm" noValidate onSubmit={handleSubmit}>
-            <Label htmlFor="login" className="bl mb1">
-                <span className="sr-only">{c('Label').t`Username`}</span>
-                <Input
-                    type="text"
-                    name="login"
-                    className="w100"
-                    autoFocus
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    id="login"
-                    required
-                    value={username}
-                    placeholder={c('Placeholder').t`Username`}
-                    onChange={onChange(setUsername)}
-                    data-cy-login="username"
-                />
+            <Label htmlFor="login" className="bl sr-only">
+                {c('Label').t`Username`}
             </Label>
-            <Label htmlFor="password" className="bl mb1">
-                <span className="sr-only">{c('Label').t`Password`}</span>
-                <Input
-                    type="password"
-                    name="password"
-                    className="w100"
-                    autoComplete="current-password"
-                    id="password"
-                    required
-                    value={password}
-                    placeholder={c('Placeholder').t`Password`}
-                    onChange={onChange(setPassword)}
-                    data-cy-login="password"
-                />
+            <Input
+                type="text"
+                name="login"
+                className="w100 mb1"
+                autoFocus
+                autoCapitalize="off"
+                autoCorrect="off"
+                id="login"
+                required
+                value={username}
+                placeholder={c('Placeholder').t`Username`}
+                onChange={onChange(setUsername)}
+                data-cy-login="username"
+            />
+            <Label htmlFor="password" className="bl sr-only">
+                {c('Label').t`Password`}
             </Label>
+            <Input
+                type="password"
+                name="password"
+                className="w100 mb1"
+                autoComplete="current-password"
+                id="password"
+                required
+                value={password}
+                placeholder={c('Placeholder').t`Password`}
+                onChange={onChange(setPassword)}
+                data-cy-login="password"
+            />
             <Button type="submit" className="pm-button-blue w100" disabled={loading} data-cy-login="submit">
                 Login
             </Button>


### PR DESCRIPTION
There is no reason for dropdown menu to allow null children. It causes errors when trying to access `.key` property for it, and null is useful when removing dropdown buttons from the menu based on some conditions.

Fixed login button widths which has been bothering me every time I see login form :)

![image](https://user-images.githubusercontent.com/944727/61353512-adfb9a00-a878-11e9-93e9-014eb99db2de.png)
