### PR TITLE
Remove signature field in address create modal

### DIFF
--- a/containers/addresses/AddressModal.js
+++ b/containers/addresses/AddressModal.js
@@ -9,7 +9,6 @@ import {
     Field,
     Label,
     Input,
-    RichTextEditor,
     useLoading,
     useNotifications,
     useEventManager,
@@ -27,18 +26,16 @@ const AddressModal = ({ onClose, member, ...rest }) => {
     const [loading, withLoading] = useLoading();
 
     const handleChange = (key) => ({ target }) => update(key, target.value);
-    const handleSignature = (value) => update('signature', value);
 
     const handleSubmit = async () => {
-        const { name: DisplayName, signature: Signature, address: Local, domain: Domain } = model;
+        const { name: DisplayName, address: Local, domain: Domain } = model;
 
         await api(
             createAddress({
                 MemberID: member.ID,
                 Local,
                 Domain,
-                DisplayName,
-                Signature
+                DisplayName
             })
         );
         await call();
@@ -91,12 +88,6 @@ const AddressModal = ({ onClose, member, ...rest }) => {
                         placeholder={c('Placeholder').t`Choose display name`}
                         onChange={handleChange('name')}
                     />
-                </Field>
-            </Row>
-            <Row>
-                <Label>{c('Label').t`Signature`}</Label>
-                <Field>
-                    <RichTextEditor value={model.signature} onChange={handleSignature} />
                 </Field>
             </Row>
         </FormModal>

--- a/containers/addresses/useAddressModal.js
+++ b/containers/addresses/useAddressModal.js
@@ -1,11 +1,9 @@
 import { useState } from 'react';
-import { replaceLineBreak } from 'proton-shared/lib/helpers/string';
 
 const toModel = ({ Self, addresses = [] }) => {
-    const [{ DisplayName, Signature } = {}] = addresses;
+    const [{ DisplayName } = {}] = addresses;
     return {
         name: Self ? DisplayName || '' : '', // DisplayName can be null
-        signature: Self ? replaceLineBreak(Signature || '') : '', // Signature can be null
         address: '',
         domain: ''
     };


### PR DESCRIPTION
Simply removes signature field. https://github.com/ProtonMail/protonmail-settings/issues/49