### PR TITLE
Small fix to FileInput

### DIFF
--- a/components/input/FileInput.js
+++ b/components/input/FileInput.js
@@ -1,10 +1,19 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-const FileInput = forwardRef(({ children, id, className, ...rest }, ref) => {
+const FileInput = forwardRef(({ children, id, className, onChange, ...rest }, ref) => {
+    const newRef = useRef();
+    const fileRef = ref || newRef;
+
+    const handleChange = (e) => {
+        onChange(e);
+        // Reset it to allow to select the same file again.
+        fileRef.current.value = '';
+    };
+
     return (
         <label className={'pm-button '.concat(className || '')} htmlFor={id}>
-            <input id={id} type="file" className="hidden" {...rest} ref={ref} />
+            <input id={id} type="file" className="hidden" onChange={handleChange} {...rest} ref={fileRef} />
             {children}
         </label>
     );

--- a/containers/keys/shared/SelectKeyFiles.js
+++ b/containers/keys/shared/SelectKeyFiles.js
@@ -9,8 +9,6 @@ const SelectKeyFiles = forwardRef(({ onFiles, autoClick, multiple, className }, 
 
     const handleFileImport = async ({ target }) => {
         const keys = await parseKeyFiles(Array.from(target.files));
-        // Reset it to allow to select the same file again.
-        fileRef.current.value = '';
         onFiles(keys);
     };
 


### PR DESCRIPTION
In order to allow FileInput to accept the same file twice we need to reset it by hand. Such a manual reset was done in external components before (see https://github.com/ProtonMail/react-components/blob/master/containers/keys/shared/SelectKeyFiles.js#L13), but we can move it inside the component.