### PR TITLE
Fix auto-reply date handling

### DIFF
--- a/containers/autoReply/AutoReplyForm/fields/EndDateField.js
+++ b/containers/autoReply/AutoReplyForm/fields/EndDateField.js
@@ -3,15 +3,10 @@ import PropTypes from 'prop-types';
 import { Row, Label, DateInput, Field } from 'react-components';
 import { c } from 'ttag';
 import moment from 'moment';
+import { startOfDayUTC } from '../../utils';
 
 const EndDateField = ({ value, onChange }) => {
-    const handleChange = (date) =>
-        onChange(
-            moment(date)
-                .utc(true)
-                .startOf('day')
-                .valueOf()
-        );
+    const handleChange = (date) => onChange(startOfDayUTC(date));
 
     return (
         <Row className="flex-spacebetween">

--- a/containers/autoReply/AutoReplyForm/fields/EndDateField.js
+++ b/containers/autoReply/AutoReplyForm/fields/EndDateField.js
@@ -5,7 +5,13 @@ import { c } from 'ttag';
 import moment from 'moment';
 
 const EndDateField = ({ value, onChange }) => {
-    const handleChange = (date) => onChange(new Date(date).getTime());
+    const handleChange = (date) =>
+        onChange(
+            moment(date)
+                .utc(true)
+                .startOf('day')
+                .valueOf()
+        );
 
     return (
         <Row className="flex-spacebetween">

--- a/containers/autoReply/AutoReplyForm/fields/StartDateField.js
+++ b/containers/autoReply/AutoReplyForm/fields/StartDateField.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { Row, Label, DateInput, Field } from 'react-components';
 import { c } from 'ttag';
 import moment from 'moment';
-import { startOfDayUTC } from '../../utils';
+import { startOfDay } from '../../utils';
 
 const StartDateField = ({ value, onChange }) => {
-    const handleChange = (date) => onChange(startOfDayUTC(date));
+    const handleChange = (date) => onChange(startOfDay(date));
 
     return (
         <Row className="flex-spacebetween">

--- a/containers/autoReply/AutoReplyForm/fields/StartDateField.js
+++ b/containers/autoReply/AutoReplyForm/fields/StartDateField.js
@@ -5,7 +5,13 @@ import { c } from 'ttag';
 import moment from 'moment';
 
 const StartDateField = ({ value, onChange }) => {
-    const handleChange = (date) => onChange(new Date(date).getTime());
+    const handleChange = (date) =>
+        onChange(
+            moment(date)
+                .utc(true)
+                .startOf('day')
+                .valueOf()
+        );
 
     return (
         <Row className="flex-spacebetween">

--- a/containers/autoReply/AutoReplyForm/fields/StartDateField.js
+++ b/containers/autoReply/AutoReplyForm/fields/StartDateField.js
@@ -3,15 +3,10 @@ import PropTypes from 'prop-types';
 import { Row, Label, DateInput, Field } from 'react-components';
 import { c } from 'ttag';
 import moment from 'moment';
+import { startOfDayUTC } from '../../utils';
 
 const StartDateField = ({ value, onChange }) => {
-    const handleChange = (date) =>
-        onChange(
-            moment(date)
-                .utc(true)
-                .startOf('day')
-                .valueOf()
-        );
+    const handleChange = (date) => onChange(startOfDayUTC(date));
 
     return (
         <Row className="flex-spacebetween">

--- a/containers/autoReply/AutoReplyForm/useAutoReplyForm.js
+++ b/containers/autoReply/AutoReplyForm/useAutoReplyForm.js
@@ -1,13 +1,10 @@
 import { useState } from 'react';
 import moment from 'moment-timezone';
-import { startOfDayUTC, getRoundedHours } from '../utils';
+import { startOfDay, getRoundedHours } from '../utils';
 
 /* 
     BE sends times and dates in UNIX format
-    FE always works with UTC
-    ---
-    FE converts from UTC to selected timezone before sending to BE
-    FE converts from selected timezone to UTC after receiving from BE
+    FE always works with locale times and converts to specified timezone before saving
 */
 const toModel = (AutoResponder) => {
     const start = moment.unix(AutoResponder.StartTime).tz(AutoResponder.Zone);
@@ -20,8 +17,8 @@ const toModel = (AutoResponder) => {
         timeZone: AutoResponder.Zone,
         subject: AutoResponder.Subject,
         enabled: AutoResponder.IsEnabled,
-        startDate: startOfDayUTC(start),
-        endDate: startOfDayUTC(end),
+        startDate: startOfDay(start),
+        endDate: startOfDay(end),
         startTime: getRoundedHours(start),
         endTime: getRoundedHours(end)
     };
@@ -34,12 +31,10 @@ const toAutoResponder = (model) => ({
     Zone: model.timeZone,
     Subject: model.subject,
     IsEnabled: model.enabled,
-    StartTime: moment
-        .utc(model.startDate + model.startTime)
+    StartTime: moment(model.startDate + model.startTime)
         .tz(model.timeZone, true)
         .unix(),
-    EndTime: moment
-        .utc(model.endDate + model.endTime)
+    EndTime: moment(model.endDate + model.endTime)
         .tz(model.timeZone, true)
         .unix()
 });

--- a/containers/autoReply/AutoReplyForm/useAutoReplyForm.js
+++ b/containers/autoReply/AutoReplyForm/useAutoReplyForm.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import moment from 'moment-timezone';
+import { startOfDayUTC, getRoundedHours } from '../utils';
 
 /* 
     BE sends times and dates in UNIX format
@@ -12,18 +13,6 @@ const toModel = (AutoResponder) => {
     const start = moment.unix(AutoResponder.StartTime).tz(AutoResponder.Zone);
     const end = moment.unix(AutoResponder.EndTime).tz(AutoResponder.Zone);
 
-    const startDate = moment(start).startOf('day');
-    const endDate = moment(end).startOf('day');
-    const startTime =
-        moment(start)
-            .startOf('hour')
-            .add(30 * Math.floor(moment(start).minutes() / 30), 'minutes')
-            .valueOf() - startDate.valueOf();
-    const endTime =
-        moment(end)
-            .startOf('hour')
-            .add(30 * Math.floor(moment(end).minutes() / 30), 'minutes')
-            .valueOf() - endDate.valueOf();
     return {
         message: AutoResponder.Message,
         duration: AutoResponder.Repeat,
@@ -31,11 +20,10 @@ const toModel = (AutoResponder) => {
         timeZone: AutoResponder.Zone,
         subject: AutoResponder.Subject,
         enabled: AutoResponder.IsEnabled,
-
-        startDate: startDate.utc(true).valueOf(),
-        endDate: endDate.utc(true).valueOf(),
-        startTime,
-        endTime
+        startDate: startOfDayUTC(start),
+        endDate: startOfDayUTC(end),
+        startTime: getRoundedHours(start),
+        endTime: getRoundedHours(end)
     };
 };
 

--- a/containers/autoReply/AutoReplyTemplate.js
+++ b/containers/autoReply/AutoReplyTemplate.js
@@ -16,9 +16,9 @@ const AutoReplyTemplate = ({ autoresponder, onEdit }) => {
     const durationLabel = getDurationOptions().find(({ value }) => value === autoresponder.Repeat).text;
     const timezone = getTimeZoneOptions().find(({ value }) => value === autoresponder.Zone).text;
 
-    // TODO: time = moment obj
-    const formatTime = (time) => {
-        const hours = moment.tz(time, autoresponder.Zone).format('LT');
+    const formatTime = (milliseconds) => {
+        const time = moment.tz(milliseconds, autoresponder.Zone);
+        const hours = time.format('LT');
 
         if (autoresponder.Repeat === AutoReplyDuration.DAILY) {
             const firstDayOfWeek = moment.localeData().firstDayOfWeek();
@@ -31,14 +31,14 @@ const AutoReplyTemplate = ({ autoresponder, onEdit }) => {
                 ? c('Duration').t`Every ${weekdays} @ ${hours}`
                 : c('Duration').t`Every day @ ${hours}`;
         } else if (autoresponder.Repeat === AutoReplyDuration.FIXED) {
-            const date = moment.tz(time, autoresponder.Zone).format('LL');
+            const date = time.format('LL');
             return `${date} @ ${hours}`;
         } else if (autoresponder.Repeat === AutoReplyDuration.WEEKLY) {
-            const dayOfWeek = moment.weekdays(Math.floor(time / DAY_MILLISECONDS));
+            const dayOfWeek = moment.weekdays(Math.floor(milliseconds / DAY_MILLISECONDS));
             return c('Duration').t`Every ${dayOfWeek} @ ${hours}`;
         } else if (autoresponder.Repeat === AutoReplyDuration.MONTHLY) {
             const dayOfMonth = getDaysOfMonthOptions().find(
-                ({ value }) => value === Math.floor(time / DAY_MILLISECONDS)
+                ({ value }) => value === Math.floor(milliseconds / DAY_MILLISECONDS)
             ).text;
             return c('Duration').t`Every ${dayOfMonth} @ ${hours}`;
         } else if (autoresponder.Repeat === AutoReplyDuration.PERMANENT) {
@@ -51,8 +51,12 @@ const AutoReplyTemplate = ({ autoresponder, onEdit }) => {
             <table>
                 <tbody>
                     <InfoLine label={c('Label').t`Duration`}>{durationLabel}</InfoLine>
-                    <InfoLine label={c('Label').t`Start`}>{formatTime(autoresponder.StartTime * 1000)}</InfoLine>
-                    <InfoLine label={c('Label').t`End`}>{formatTime(autoresponder.EndTime * 1000)}</InfoLine>
+                    <InfoLine label={c('Label').t`Start`}>
+                        {formatTime(moment.unix(autoresponder.StartTime).valueOf())}
+                    </InfoLine>
+                    <InfoLine label={c('Label').t`End`}>
+                        {formatTime(moment.unix(autoresponder.EndTime).valueOf())}
+                    </InfoLine>
                     <InfoLine label={c('Label').t`Timezone`}>{timezone}</InfoLine>
                     <InfoLine plain label={c('Label').t`Message`}>
                         <div dangerouslySetInnerHTML={{ __html: autoresponder.Message }} />

--- a/containers/autoReply/AutoReplyTemplate.js
+++ b/containers/autoReply/AutoReplyTemplate.js
@@ -16,8 +16,9 @@ const AutoReplyTemplate = ({ autoresponder, onEdit }) => {
     const durationLabel = getDurationOptions().find(({ value }) => value === autoresponder.Repeat).text;
     const timezone = getTimeZoneOptions().find(({ value }) => value === autoresponder.Zone).text;
 
+    // TODO: time = moment obj
     const formatTime = (time) => {
-        const hours = moment.utc(time).format('LT');
+        const hours = moment.tz(time, autoresponder.Zone).format('LT');
 
         if (autoresponder.Repeat === AutoReplyDuration.DAILY) {
             const firstDayOfWeek = moment.localeData().firstDayOfWeek();
@@ -30,7 +31,7 @@ const AutoReplyTemplate = ({ autoresponder, onEdit }) => {
                 ? c('Duration').t`Every ${weekdays} @ ${hours}`
                 : c('Duration').t`Every day @ ${hours}`;
         } else if (autoresponder.Repeat === AutoReplyDuration.FIXED) {
-            const date = moment(time).format('LL');
+            const date = moment.tz(time, autoresponder.Zone).format('LL');
             return `${date} @ ${hours}`;
         } else if (autoresponder.Repeat === AutoReplyDuration.WEEKLY) {
             const dayOfWeek = moment.weekdays(Math.floor(time / DAY_MILLISECONDS));

--- a/containers/autoReply/utils.js
+++ b/containers/autoReply/utils.js
@@ -94,8 +94,7 @@ export const getRoundedHours = (time) => {
         .valueOf();
 };
 
-export const startOfDayUTC = (date) =>
+export const startOfDay = (date) =>
     moment(date)
-        .utc(true)
         .startOf('day')
         .valueOf();

--- a/containers/autoReply/utils.js
+++ b/containers/autoReply/utils.js
@@ -84,3 +84,18 @@ export const getDaysOfMonthOptions = () => [
     { text: c('Option').t`30th of the month`, value: 29 },
     { text: c('Option').t`31st of the month`, value: 30 }
 ];
+
+export const getRoundedHours = (time) => {
+    const startOfDay = moment(time).startOf('day');
+
+    return moment(moment(time).diff(startOfDay))
+        .startOf('hour')
+        .add(30 * Math.floor(moment(time).minutes() / 30), 'minutes')
+        .valueOf();
+};
+
+export const startOfDayUTC = (date) =>
+    moment(date)
+        .utc(true)
+        .startOf('day')
+        .valueOf();


### PR DESCRIPTION
Dates were saved in locale timezone, not the one specified. Went over the whole error handling and refactored it.

Fixes: https://github.com/ProtonMail/protonmail-settings/issues/74