### PR TITLE
Fix for small bug in ObserverSections component

### DIFF
--- a/components/container/ObserverSection.js
+++ b/components/container/ObserverSection.js
@@ -4,16 +4,7 @@ import 'intersection-observer';
 import { debounce } from 'proton-shared/lib/helpers/function';
 
 import { buildThresholds, indexOfMax } from '../../helpers/intersectionObserver';
-
-/**
- * IntersectionObserverEntry.intersectionRatio is a bit buggy, and looks to be
- * slightly off sometimes. This is a manual fix for this.
- * @param {Number} ratio
- */
-const toFaithful = (ratio) => {
-    const rounded = Math.round(ratio * 100) / 100;
-    return Math.min(rounded, 1);
-};
+import { withDecimalPrecision } from 'proton-shared/lib/helpers/math';
 
 const ObserverSection = ({
     id,
@@ -46,7 +37,7 @@ const ObserverSection = ({
             entries.forEach((entry) => {
                 setIntersectionData(({ intersectionRatios, listOfIds }) => {
                     const newIntersectionRatios = intersectionRatios.slice();
-                    newIntersectionRatios[index] = toFaithful(entry.intersectionRatio);
+                    newIntersectionRatios[index] = withDecimalPrecision(entry.intersectionRatio, 2);
                     const idToDisplay = listOfIds[indexOfMax(newIntersectionRatios)];
                     return {
                         intersectionRatios: newIntersectionRatios,

--- a/components/container/ObserverSection.js
+++ b/components/container/ObserverSection.js
@@ -5,6 +5,16 @@ import { debounce } from 'proton-shared/lib/helpers/function';
 
 import { buildThresholds, indexOfMax } from '../../helpers/intersectionObserver';
 
+/**
+ * IntersectionObserverEntry.intersectionRatio is a bit buggy, and looks to be
+ * slightly off sometimes. This is a manual fix for this.
+ * @param {Number} ratio
+ */
+const toFaithful = (ratio) => {
+    const rounded = Math.round(ratio * 100) / 100;
+    return Math.min(rounded, 1);
+};
+
 const ObserverSection = ({
     id,
     className,
@@ -36,7 +46,7 @@ const ObserverSection = ({
             entries.forEach((entry) => {
                 setIntersectionData(({ intersectionRatios, listOfIds }) => {
                     const newIntersectionRatios = intersectionRatios.slice();
-                    newIntersectionRatios[index] = Math.min(entry.intersectionRatio, 1); // manual fix for bug IntersectionObserverEntry.intersectionRatio > 1
+                    newIntersectionRatios[index] = toFaithful(entry.intersectionRatio);
                     const idToDisplay = listOfIds[indexOfMax(newIntersectionRatios)];
                     return {
                         intersectionRatios: newIntersectionRatios,


### PR DESCRIPTION
I noticed there was a small bug in the ObserverSections component when working in combination with the subsidebar. It seems when clicking on one of the links of the subside bar for a certain `id`, the intersection ratio for section `id` does not happen to be `1`, but instead a number close to it like `0.998...`. If a small section below `id`, say `id2`, happens to have an intersection ratio equal to `1`, the url displayed will be `...#id2` after clicking the link on the subsidebar for `id`, which is obviously not nice.

By rounding to two decimal places the intersection ratios, the bug goes away.

Requires https://github.com/ProtonMail/proton-shared/pull/32