### PR TITLE
Add human verification support on all routes

### DIFF
--- a/containers/api/Captcha.js
+++ b/containers/api/Captcha.js
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useConfig } from 'react-components';
+import { getHost } from 'proton-shared/lib/helpers/url';
+import { createUrl } from 'proton-shared/lib/fetch/helpers';
+
+const Captcha = ({ token, onSubmit }) => {
+    const [style, setStyle] = useState({});
+    const { API_URL } = useConfig();
+    const client = 'web';
+    const host = getHost(API_URL);
+    const url = createUrl('https://secure.protonmail.com/captcha/captcha.html', { token, client, host });
+    const src = url.toString();
+
+    const receiveMessage = (event) => {
+        const { origin, originalEvent, data } = event;
+
+        if (typeof origin === 'undefined' && typeof originalEvent.origin === 'undefined') {
+            return;
+        }
+
+        // For Chrome, the origin property is in the event.originalEvent object.
+        const source = origin || originalEvent.origin;
+
+        // Change window.location.origin to wherever this is hosted ( 'https://secure.protonmail.com:443' )
+        if (source !== 'https://secure.protonmail.com') {
+            return;
+        }
+
+        if (data.type === 'pm_captcha') {
+            onSubmit(data.token);
+        }
+
+        if (data.type === 'pm_height') {
+            const height = event.data.height + 40;
+            setStyle({ height: `${height}px` });
+        }
+    };
+
+    useEffect(() => {
+        window.addEventListener('message', receiveMessage, false);
+
+        return () => {
+            window.removeEventListener('message', receiveMessage, false);
+        };
+    }, []);
+
+    return <iframe src={src} style={style} sandbox="allow-scripts allow-same-origin" />;
+};
+
+Captcha.propTypes = {
+    token: PropTypes.string.isRequired,
+    onSubmit: PropTypes.func
+};
+
+export default Captcha;

--- a/containers/api/Captcha.js
+++ b/containers/api/Captcha.js
@@ -12,7 +12,7 @@ const Captcha = ({ token, onSubmit }) => {
     const url = createUrl('https://secure.protonmail.com/captcha/captcha.html', { token, client, host });
     const src = url.toString();
 
-    const receiveMessage = (event) => {
+    const handleMessage = (event) => {
         const { origin, originalEvent, data } = event;
 
         if (typeof origin === 'undefined' && typeof originalEvent.origin === 'undefined') {
@@ -38,10 +38,10 @@ const Captcha = ({ token, onSubmit }) => {
     };
 
     useEffect(() => {
-        window.addEventListener('message', receiveMessage, false);
+        window.addEventListener('message', handleMessage, false);
 
         return () => {
-            window.removeEventListener('message', receiveMessage, false);
+            window.removeEventListener('message', handleMessage, false);
         };
     }, []);
 

--- a/containers/api/Captcha.js
+++ b/containers/api/Captcha.js
@@ -5,7 +5,7 @@ import { getHost } from 'proton-shared/lib/helpers/url';
 import { createUrl } from 'proton-shared/lib/fetch/helpers';
 
 const Captcha = ({ token, onSubmit }) => {
-    const [style, setStyle] = useState({});
+    const [style, setStyle] = useState();
     const { API_URL } = useConfig();
     const client = 'web';
     const host = getHost(API_URL);

--- a/containers/api/HumanVerificationModal.js
+++ b/containers/api/HumanVerificationModal.js
@@ -13,6 +13,11 @@ const HumanVerificationModal = ({ token, onSubmit, ...rest }) => {
     const { VerifyMethods = [] } = result;
     const handleChange = ({ target }) => target.checked && setMethod(target.value);
 
+    const handleCaptcha = (token) => {
+        onSubmit(token, method);
+        rest.onClose();
+    };
+
     return (
         <FormModal hasClose={false} noValidate={true} title={title} loading={loading} {...rest}>
             <Alert>{c('Info').t`For security reasons, please verify that you are not a robot.`}</Alert>
@@ -31,7 +36,7 @@ const HumanVerificationModal = ({ token, onSubmit, ...rest }) => {
                         <span>{c('Label').t`Captcha`}</span>
                     </Label>
                     <div className="w100">
-                        <Captcha token={token} onSubmit={(token) => onSubmit(token, method)} />
+                        <Captcha token={token} onSubmit={handleCaptcha} />
                     </div>
                 </Row>
             ) : null}

--- a/containers/api/HumanVerificationModal.js
+++ b/containers/api/HumanVerificationModal.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { FormModal, Alert, Row, Label, Radio, useApiResult } from 'react-components';
+import { c } from 'ttag';
+import { getHumanVerificationMethods } from 'proton-shared/lib/api/users';
+
+import Captcha from './Captcha';
+
+const HumanVerificationModal = ({ token, onSubmit, ...rest }) => {
+    const title = c('Title').t`Human verification`;
+    const { result, loading } = useApiResult(getHumanVerificationMethods, []);
+    const [method, setMethod] = useState('captcha');
+    const { VerifyMethods = [] } = result;
+    const handleChange = ({ target }) => target.checked && setMethod(target.value);
+
+    return (
+        <FormModal hasClose={false} noValidate={true} title={title} loading={loading} {...rest}>
+            <Alert>{c('Info').t`For security reasons, please verify that you are not a robot.`}</Alert>
+            {VerifyMethods.includes('captcha') ? (
+                <Row>
+                    <Label htmlFor="captcha">
+                        <Radio
+                            id="captcha"
+                            checked={method === 'captcha'}
+                            value="captcha"
+                            className="mr0-5"
+                            onChange={handleChange}
+                        />
+                        <span>{c('Label').t`Captcha`}</span>
+                    </Label>
+                    <div className="w100">
+                        <Captcha token={token} onSubmit={onSubmit} />
+                    </div>
+                </Row>
+            ) : null}
+        </FormModal>
+    );
+};
+
+HumanVerificationModal.propTypes = {
+    token: PropTypes.string,
+    onSubmit: PropTypes.func
+};
+
+export default HumanVerificationModal;

--- a/containers/api/HumanVerificationModal.js
+++ b/containers/api/HumanVerificationModal.js
@@ -1,16 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormModal, Alert, Row, Label, Radio, useApiResult } from 'react-components';
+import { FormModal, Alert, Row, Label, Radio } from 'react-components';
 import { c } from 'ttag';
-import { getHumanVerificationMethods } from 'proton-shared/lib/api/users';
 
 import Captcha from './Captcha';
 
-const HumanVerificationModal = ({ token, onSubmit, ...rest }) => {
+const HumanVerificationModal = ({ token, methods = [], onSubmit, ...rest }) => {
     const title = c('Title').t`Human verification`;
-    const { result, loading } = useApiResult(getHumanVerificationMethods, []);
     const [method, setMethod] = useState('captcha');
-    const { VerifyMethods = [] } = result;
     const handleChange = ({ target }) => target.checked && setMethod(target.value);
 
     const handleCaptcha = (token) => {
@@ -19,12 +16,12 @@ const HumanVerificationModal = ({ token, onSubmit, ...rest }) => {
     };
 
     return (
-        <FormModal hasClose={false} noValidate={true} title={title} loading={loading} {...rest}>
+        <FormModal hasClose={false} noValidate={true} title={title} {...rest}>
             <Alert>{c('Info').t`For security reasons, please verify that you are not a robot.`}</Alert>
-            {VerifyMethods.includes('captcha') ? (
+            {methods.includes('captcha') ? (
                 <Row>
                     <Label htmlFor="captcha">
-                        {VerifyMethods.length ? (
+                        {methods.length ? (
                             <Radio
                                 id="captcha"
                                 checked={method === 'captcha'}
@@ -46,6 +43,7 @@ const HumanVerificationModal = ({ token, onSubmit, ...rest }) => {
 
 HumanVerificationModal.propTypes = {
     token: PropTypes.string,
+    methods: PropTypes.arrayOf(PropTypes.string),
     onSubmit: PropTypes.func
 };
 

--- a/containers/api/HumanVerificationModal.js
+++ b/containers/api/HumanVerificationModal.js
@@ -19,17 +19,19 @@ const HumanVerificationModal = ({ token, onSubmit, ...rest }) => {
             {VerifyMethods.includes('captcha') ? (
                 <Row>
                     <Label htmlFor="captcha">
-                        <Radio
-                            id="captcha"
-                            checked={method === 'captcha'}
-                            value="captcha"
-                            className="mr0-5"
-                            onChange={handleChange}
-                        />
+                        {VerifyMethods.length ? (
+                            <Radio
+                                id="captcha"
+                                checked={method === 'captcha'}
+                                value="captcha"
+                                className="mr0-5"
+                                onChange={handleChange}
+                            />
+                        ) : null}
                         <span>{c('Label').t`Captcha`}</span>
                     </Label>
                     <div className="w100">
-                        <Captcha token={token} onSubmit={onSubmit} />
+                        <Captcha token={token} onSubmit={(token) => onSubmit(token, method)} />
                     </div>
                 </Row>
             ) : null}

--- a/containers/api/HumanVerificationModal.js
+++ b/containers/api/HumanVerificationModal.js
@@ -21,7 +21,7 @@ const HumanVerificationModal = ({ token, methods = [], onSubmit, ...rest }) => {
             {methods.includes('captcha') ? (
                 <Row>
                     <Label htmlFor="captcha">
-                        {methods.length ? (
+                        {methods.length > 1 ? (
                             <Radio
                                 id="captcha"
                                 checked={method === 'captcha'}

--- a/containers/api/HumanVerificationModal.js
+++ b/containers/api/HumanVerificationModal.js
@@ -1,37 +1,25 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormModal, Alert, Row, Label, Radio } from 'react-components';
+import { FormModal, Alert, Row, Label } from 'react-components';
 import { c } from 'ttag';
 
 import Captcha from './Captcha';
 
-const HumanVerificationModal = ({ token, methods = [], onSubmit, ...rest }) => {
+const HumanVerificationModal = ({ token, methods = [], onSuccess, ...rest }) => {
     const title = c('Title').t`Human verification`;
-    const [method, setMethod] = useState('captcha');
-    const handleChange = ({ target }) => target.checked && setMethod(target.value);
+    const [method] = useState('captcha');
 
     const handleCaptcha = (token) => {
-        onSubmit(token, method);
+        onSuccess({ token, method });
         rest.onClose();
     };
 
     return (
-        <FormModal hasClose={false} noValidate={true} title={title} {...rest}>
-            <Alert>{c('Info').t`For security reasons, please verify that you are not a robot.`}</Alert>
+        <FormModal hasClose={false} hasSubmit={false} title={title} {...rest}>
+            <Alert type="warning">{c('Info').t`For security reasons, please verify that you are not a robot.`}</Alert>
             {methods.includes('captcha') ? (
                 <Row>
-                    <Label htmlFor="captcha">
-                        {methods.length > 1 ? (
-                            <Radio
-                                id="captcha"
-                                checked={method === 'captcha'}
-                                value="captcha"
-                                className="mr0-5"
-                                onChange={handleChange}
-                            />
-                        ) : null}
-                        <span>{c('Label').t`Captcha`}</span>
-                    </Label>
+                    <Label htmlFor="captcha">{c('Label').t`Captcha`}</Label>
                     <div className="w100">
                         <Captcha token={token} onSubmit={handleCaptcha} />
                     </div>
@@ -44,7 +32,7 @@ const HumanVerificationModal = ({ token, methods = [], onSubmit, ...rest }) => {
 HumanVerificationModal.propTypes = {
     token: PropTypes.string,
     methods: PropTypes.arrayOf(PropTypes.string),
-    onSubmit: PropTypes.func
+    onSuccess: PropTypes.func
 };
 
 export default HumanVerificationModal;


### PR DESCRIPTION
### TODO

- [x] Connect `HumanVerificationModal` to 9001 handler (the error result returns the `Token` and `VerifyMethods`)
- [x] Captcha view
- [x] Modal

### Note

- The API is not yet ready.

Fix https://github.com/ProtonMail/react-components/issues/130