### PR TITLE
ProtonVPN Downloads page sections

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,8 @@
 module.exports = {
     presets: ['@babel/preset-env', '@babel/preset-react'],
-    plugins: ['@babel/plugin-proposal-object-rest-spread', '@babel/plugin-transform-runtime']
+    plugins: [
+        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-transform-runtime',
+        'transform-require-context'
+    ]
 };

--- a/components/input/RadioGroup.js
+++ b/components/input/RadioGroup.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Radio } from 'react-components';
+import PropTypes from 'prop-types';
+
+const RadioGroup = ({ name, options, onChange, value }) => {
+    const handleChangePlatform = (optionValue) => () => onChange(optionValue);
+
+    return options.map((option, i) => (
+        <Radio
+            key={i}
+            onChange={handleChangePlatform(option.value)}
+            checked={value === option.value}
+            name={name}
+            className="mr2"
+        >
+            {option.label}
+        </Radio>
+    ));
+};
+
+RadioGroup.propTypes = {
+    name: PropTypes.string.isRequired,
+    value: PropTypes.any.isRequired,
+    onChange: PropTypes.func.isRequired,
+    options: PropTypes.arrayOf(
+        PropTypes.shape({
+            label: PropTypes.node,
+            value: PropTypes.any
+        }).isRequired
+    )
+};
+
+export default RadioGroup;

--- a/containers/userVPN/Provider.js
+++ b/containers/userVPN/Provider.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useApiResult } from 'react-components';
+import { getClientVPNInfo } from 'proton-shared/lib/api/vpn';
+
+import UserVPNContext from './userVPNContext';
+
+const UserVPNProvider = ({ children }) => {
+    const value = useApiResult(getClientVPNInfo, []);
+
+    return <UserVPNContext.Provider value={value}>{children}</UserVPNContext.Provider>;
+};
+
+UserVPNProvider.propTypes = {
+    children: PropTypes.node.isRequired
+};
+
+export default UserVPNProvider;

--- a/containers/userVPN/index.js
+++ b/containers/userVPN/index.js
@@ -1,0 +1,2 @@
+export { default as useUserVPN } from './useUserVPN';
+export { default as UserVPNProvider } from './Provider';

--- a/containers/userVPN/useUserVPN.js
+++ b/containers/userVPN/useUserVPN.js
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+
+import UserVPNContext from './userVPNContext';
+
+const useUserVPN = () => {
+    const { result = {}, loading } = useContext(UserVPNContext);
+
+    const userVPN = result.VPN;
+
+    const isTrial = userVPN && userVPN.PlanName === 'trial';
+    const isBasic = userVPN && userVPN.PlanName === 'vpnbasic';
+    const tier = isTrial ? 0 : userVPN && userVPN.MaxTier;
+
+    return { loading, userVPN, isTrial, isBasic, tier };
+};
+
+export default useUserVPN;

--- a/containers/userVPN/userVPNContext.js
+++ b/containers/userVPN/userVPNContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext();

--- a/containers/vpn/OpenVPNConfigurationSection/ConfigsTable.js
+++ b/containers/vpn/OpenVPNConfigurationSection/ConfigsTable.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    Table,
+    TableBody,
+    TableRow,
+    SmallButton,
+    Tooltip,
+    TableCell,
+    useApiWithoutResult,
+    Icon
+} from 'react-components';
+import { c } from 'ttag';
+import LoadIndicator from './LoadIndicator';
+import Country from './Country';
+import { getVPNServerConfig } from 'proton-shared/lib/api/vpn';
+import downloadFile from 'proton-shared/lib/helpers/downloadFile';
+import { isP2PEnabled, isTorEnabled } from './utils';
+
+export const CATEGORY = {
+    SECURE_CORE: 'SecureCore',
+    COUNTRY: 'Country',
+    SERVER: 'Server'
+};
+
+const PlusBadge = () => (
+    <Tooltip title="Plus">
+        <div className="aligncenter color-white rounded bg-plus" style={{ width: 22, height: 22 }}>
+            P
+        </div>
+    </Tooltip>
+);
+
+const ServerDown = () => (
+    <Tooltip title={c('Info').t`Server is currently down`}>
+        <div className="flex inline-flex-vcenter">
+            <Icon fill="warning" size={20} name="attention" />
+        </div>
+    </Tooltip>
+);
+
+const P2P = () => (
+    <span className="ml0-5">
+        <Tooltip title={c('Info').t`P2P`}>p2p</Tooltip>
+    </span>
+);
+
+const Tor = () => (
+    <span className="ml0-5">
+        <Tooltip title={c('Info').t`Tor`}>tor</Tooltip>
+    </span>
+);
+
+// TODO: Add icons instead of text for p2p and tor when they are ready
+const ConfigsTable = ({ loading, servers = [], platform, protocol, category, isUpgradeRequired }) => {
+    const { request } = useApiWithoutResult(getVPNServerConfig);
+
+    const handleClickDownload = (server) => async () => {
+        const { ID, ExitCountry, Domain } = server;
+        const buffer = await request({
+            LogicalID: category === CATEGORY.COUNTRY ? undefined : ID,
+            Platform: platform,
+            Protocol: protocol,
+            Country: ExitCountry
+        });
+        const blob = new Blob([buffer], { type: 'application/x-openvpn-profile' });
+        downloadFile(blob, `${Domain}.${protocol}.ovpn`);
+    };
+
+    return (
+        <Table>
+            <thead>
+                <tr>
+                    <TableCell className="w50" type="header">
+                        {category === CATEGORY.SERVER ? c('TableHeader').t`Name` : c('TableHeader').t`Country`}
+                    </TableCell>
+                    <TableCell className="w30" type="header">{c('TableHeader').t`Status`}</TableCell>
+                    <TableCell className="w20" type="header">{c('TableHeader').t`Action`}</TableCell>
+                </tr>
+            </thead>
+            <TableBody loading={loading} colSpan={3}>
+                {servers.map((server) => (
+                    <TableRow
+                        key={server.ID}
+                        cells={[
+                            category === CATEGORY.SERVER ? server.Name : <Country key="country" server={server} />,
+                            <div className="inline-flex-vcenter" key="status">
+                                <span className="mr1-5">{server.Tier === 2 && <PlusBadge />}</span>
+                                {!server.Status && <ServerDown />}
+                                <LoadIndicator server={server} />
+                                {isP2PEnabled(server.Features) && <P2P />}
+                                {isTorEnabled(server.Features) && <Tor />}
+                            </div>,
+                            isUpgradeRequired(server) ? (
+                                <Tooltip key="download" title={c('Info').t`Plan upgrade required`}>
+                                    <SmallButton disabled>{c('Action').t`Download`}</SmallButton>
+                                </Tooltip>
+                            ) : (
+                                <SmallButton key="download" onClick={handleClickDownload(server)}>{c('Action')
+                                    .t`Download`}</SmallButton>
+                            )
+                        ]}
+                    />
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
+
+ConfigsTable.propTypes = {
+    isUpgradeRequired: PropTypes.func.isRequired,
+    isGroupedByCountry: PropTypes.bool,
+    category: PropTypes.oneOf([CATEGORY.SECURE_CORE, CATEGORY.COUNTRY, CATEGORY.SERVER]),
+    platform: PropTypes.string,
+    protocol: PropTypes.string,
+    loading: PropTypes.bool,
+    servers: PropTypes.arrayOf(
+        PropTypes.shape({
+            ID: PropTypes.string,
+            Country: PropTypes.string,
+            EntryCountry: PropTypes.string,
+            ExitCountry: PropTypes.string,
+            Domain: PropTypes.string,
+            Features: PropTypes.number,
+            Load: PropTypes.number,
+            Tier: PropTypes.number
+        })
+    )
+};
+
+export default ConfigsTable;

--- a/containers/vpn/OpenVPNConfigurationSection/Country.js
+++ b/containers/vpn/OpenVPNConfigurationSection/Country.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { getCountryByAbbr } from 'react-components/helpers/countries';
+const flags = require.context('design-system/assets/img/shared/flags/4x3', true, /.svg$/);
+
+const getFlagSvg = (abbreviation) => flags(`./${abbreviation.toLowerCase()}.svg`);
+
+const Country = ({ server: { EntryCountry, ExitCountry } }) => {
+    const isRouted = EntryCountry && EntryCountry !== ExitCountry;
+
+    return (
+        <div className="inline-flex-vcenter">
+            <img width={20} className="mr0-5" src={getFlagSvg(ExitCountry)} alt={`flag-${ExitCountry}`} />
+            {getCountryByAbbr(ExitCountry)}
+            {isRouted && (
+                <span className="ml0-25 opacity-50">{c('CountryInfo').t`(via ${getCountryByAbbr(EntryCountry)})`}</span>
+            )}
+        </div>
+    );
+};
+
+Country.propTypes = {
+    server: PropTypes.shape({
+        EntryCountry: PropTypes.string,
+        ExitCountry: PropTypes.string
+    })
+};
+
+export default Country;

--- a/containers/vpn/OpenVPNConfigurationSection/Country.js
+++ b/containers/vpn/OpenVPNConfigurationSection/Country.js
@@ -8,14 +8,13 @@ const getFlagSvg = (abbreviation) => flags(`./${abbreviation.toLowerCase()}.svg`
 
 const Country = ({ server: { EntryCountry, ExitCountry } }) => {
     const isRouted = EntryCountry && EntryCountry !== ExitCountry;
+    const exitCountryName = getCountryByAbbr(EntryCountry);
 
     return (
         <div className="inline-flex-vcenter">
             <img width={20} className="mr0-5" src={getFlagSvg(ExitCountry)} alt={`flag-${ExitCountry}`} />
             {getCountryByAbbr(ExitCountry)}
-            {isRouted && (
-                <span className="ml0-25 opacity-50">{c('CountryInfo').t`(via ${getCountryByAbbr(EntryCountry)})`}</span>
-            )}
+            {isRouted && <span className="ml0-25 opacity-50">{c('CountryInfo').t`(via ${exitCountryName})`}</span>}
         </div>
     );
 };

--- a/containers/vpn/OpenVPNConfigurationSection/Country.js
+++ b/containers/vpn/OpenVPNConfigurationSection/Country.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { getCountryByAbbr } from 'react-components/helpers/countries';
+
+// require.context would be replaced by a dummy function in tests
 const flags = require.context('design-system/assets/img/shared/flags/4x3', true, /.svg$/);
 
 const getFlagSvg = (abbreviation) => flags(`./${abbreviation.toLowerCase()}.svg`);

--- a/containers/vpn/OpenVPNConfigurationSection/LoadIndicator.js
+++ b/containers/vpn/OpenVPNConfigurationSection/LoadIndicator.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from 'react-components';
+import { c } from 'ttag';
+
+const LoadIndicator = ({ server: { Load = 0 } }) => (
+    <Tooltip title={c('Info').t`Server load`}>
+        <div className="flex inline-flex-vcenter">
+            <div className="load-indicator">
+                <div className="load-indicator-overlay" style={{ marginTop: `${-Load * 50}%` }}></div>
+            </div>
+            <div className="ml0-5">{Load}%</div>
+        </div>
+    </Tooltip>
+);
+
+LoadIndicator.propTypes = {
+    server: PropTypes.shape({
+        Load: PropTypes.number
+    })
+};
+
+export default LoadIndicator;

--- a/containers/vpn/OpenVPNConfigurationSection/OpenVPNConfigurationSection.js
+++ b/containers/vpn/OpenVPNConfigurationSection/OpenVPNConfigurationSection.js
@@ -1,0 +1,235 @@
+import React, { useState } from 'react';
+import { c } from 'ttag';
+import {
+    Alert,
+    Row,
+    Radio,
+    ButtonGroup,
+    Group,
+    useApiResult,
+    SubTitle,
+    useApiWithoutResult,
+    Button,
+    Block,
+    useUser,
+    Tooltip,
+    useSortedList,
+    useUserVPN
+} from 'react-components';
+import { queryVPNLogicalServerInfo, getVPNServerConfig } from 'proton-shared/lib/api/vpn';
+import ConfigsTable, { CATEGORY } from './ConfigsTable';
+import { isSecureCoreEnabled } from './utils';
+import { groupWith, minBy } from 'proton-shared/lib/helpers/array';
+import ServerConfigs from './ServerConfigs';
+import downloadFile from 'proton-shared/lib/helpers/downloadFile';
+import { getCountryByAbbr } from 'react-components/helpers/countries';
+import { SORT_DIRECTION } from 'proton-shared/lib/constants';
+
+const PLATFORM = {
+    MACOS: 'macOS',
+    LINUX: 'Linux',
+    WINDOWS: 'Windows',
+    ANDROID: 'Android',
+    IOS: 'iOS',
+    ROUTER: 'Router'
+};
+
+const PROTOCOL = {
+    TCP: 'tcp',
+    UDP: 'udp'
+};
+
+const OpenVPNConfigurationSection = () => {
+    const [platform, setPlatform] = useState(PLATFORM.MACOS);
+    const [protocol, setProtocol] = useState(PROTOCOL.UDP);
+    const [category, setCategory] = useState(CATEGORY.SECURE_CORE);
+    const { request } = useApiWithoutResult(getVPNServerConfig);
+    const { loading, result = {} } = useApiResult(queryVPNLogicalServerInfo, []);
+    const { loading: vpnLoading, tier, isBasic, userVPN } = useUserVPN();
+    const { hasPaidVPN } = useUser();
+
+    const downloadAllConfigs = async () => {
+        const buffer = await request({
+            Category: category,
+            Platform: platform,
+            Protocol: protocol,
+            Tier: tier
+        });
+        const blob = new Blob([buffer], { type: 'application/zip' });
+        downloadFile(blob, 'ProtonVPN_server_configs.zip');
+    };
+
+    const handleSelectConfig = (option) => () => setCategory(option);
+
+    const servers = (result.LogicalServers || []).map((server) => {
+        // Server returns UK instead of GB
+        const correctAbbr = (abbr) => (abbr === 'UK' ? 'GB' : abbr);
+        const ExitCountry = correctAbbr(server.ExitCountry);
+        const EntryCountry = correctAbbr(server.EntryCountry);
+        return {
+            ...server,
+            Country: getCountryByAbbr(ExitCountry),
+            ExitCountry,
+            EntryCountry
+        };
+    });
+
+    const { sortedList: allServers } = useSortedList(servers, { key: 'Country', direction: SORT_DIRECTION.ASC });
+
+    const secureCoreServers = allServers.filter(({ Features }) => isSecureCoreEnabled(Features));
+    const countryServers = groupWith(
+        (a, b) => a.ExitCountry === b.ExitCountry,
+        allServers.filter(({ Tier }) => Tier === 1)
+    ).map((groups) => minBy(({ Load }) => Number(Load), groups));
+
+    const handleChangePlatform = (platform) => () => setPlatform(platform);
+    const handleChangeProtocol = (protocol) => () => setProtocol(protocol);
+
+    const isUpgradeRequiredForSecureCore = () => !userVPN || !hasPaidVPN || isBasic;
+    const isUpgradeRequiredForCountries = () => !userVPN || !hasPaidVPN;
+    const isUpgradeRequiredForDownloadAll =
+        !userVPN || (!hasPaidVPN && category !== CATEGORY.SERVER) || (isBasic && category === CATEGORY.SECURE_CORE);
+
+    return (
+        <>
+            <SubTitle id="openvpn-configuration-files">{c('Title').t`OpenVPN Configuration Files`}</SubTitle>
+            <Alert>
+                {c('Info').t`Use this section to generate config files for third party VPN clients
+                    or when setting up a connection on a router. If you use a native ProtonVPN
+                    client to connect, you do not need to manually handle these configuration files.
+                `}
+            </Alert>
+
+            <h3 className="mt2">{c('Title').t`1. Select platform`}</h3>
+            <Row>
+                <Radio
+                    onChange={handleChangePlatform(PLATFORM.MACOS)}
+                    checked={platform === PLATFORM.MACOS}
+                    name="platform"
+                    className="mr2"
+                >{c('Option').t`MacOS`}</Radio>
+                <Radio
+                    onChange={handleChangePlatform(PLATFORM.LINUX)}
+                    checked={platform === PLATFORM.LINUX}
+                    name="platform"
+                    className="mr2"
+                >{c('Option').t`Linux`}</Radio>
+                <Radio
+                    onChange={handleChangePlatform(PLATFORM.WINDOWS)}
+                    checked={platform === PLATFORM.WINDOWS}
+                    name="platform"
+                    className="mr2"
+                >{c('Option').t`Windows`}</Radio>
+                <Radio
+                    onChange={handleChangePlatform(PLATFORM.ANDROID)}
+                    checked={platform === PLATFORM.ANDROID}
+                    name="platform"
+                    className="mr2"
+                >{c('Option').t`Android`}</Radio>
+                <Radio
+                    onChange={handleChangePlatform(PLATFORM.IOS)}
+                    checked={platform === PLATFORM.IOS}
+                    name="platform"
+                    className="mr2"
+                >{c('Option').t`iOS`}</Radio>
+                <Radio
+                    onChange={handleChangePlatform(PLATFORM.ROUTER)}
+                    checked={platform === PLATFORM.ROUTER}
+                    name="platform"
+                    className="mr2"
+                >{c('Option').t`Router`}</Radio>
+            </Row>
+
+            <h3 className="mt2">{c('Title').t`2. Select protocol`}</h3>
+            <Row>
+                <Radio
+                    onChange={handleChangeProtocol(PROTOCOL.UDP)}
+                    checked={protocol === PROTOCOL.UDP}
+                    name="protocol"
+                    className="mr2"
+                >{c('Option').t`UDP`}</Radio>
+                <Radio
+                    onChange={handleChangeProtocol(PROTOCOL.TCP)}
+                    checked={protocol === PROTOCOL.TCP}
+                    name="protocol"
+                    className="mr2"
+                >{c('Option').t`TCP`}</Radio>
+            </Row>
+
+            <h3 className="mt2">{c('Title').t`3. Select connection and download`}</h3>
+            <Group className="mb1-5">
+                <ButtonGroup
+                    onClick={handleSelectConfig(CATEGORY.SECURE_CORE)}
+                    disabled={category === CATEGORY.SECURE_CORE}
+                >{c('Tab').t`Secure Core Configs`}</ButtonGroup>
+                <ButtonGroup onClick={handleSelectConfig(CATEGORY.COUNTRY)} disabled={category === CATEGORY.COUNTRY}>{c(
+                    'Tab'
+                ).t`Country Configs`}</ButtonGroup>
+                <ButtonGroup onClick={handleSelectConfig(CATEGORY.SERVER)} disabled={category === CATEGORY.SERVER}>{c(
+                    'Tab'
+                ).t`Server Configs`}</ButtonGroup>
+            </Group>
+
+            <Block>
+                {category === CATEGORY.SECURE_CORE && (
+                    <>
+                        <h3>{c('Title').t`Secure Core Configs`}</h3>
+                        <Alert learnMore="https://protonvpn.com/support/secure-core-vpn">
+                            {c('Info')
+                                .t`Secure Core configurations add additional protection against VPN endpoint compromise.`}
+                        </Alert>
+                        {isUpgradeRequiredForSecureCore() && (
+                            <Alert learnMore="https://account.protonvpn.com/dashboard">
+                                {c('Info').t`ProtonVPN Plus or Visionary required for Secure Core feature.`}
+                            </Alert>
+                        )}
+                        <ConfigsTable
+                            isUpgradeRequired={isUpgradeRequiredForSecureCore}
+                            platform={platform}
+                            protocol={protocol}
+                            loading={loading}
+                            servers={secureCoreServers}
+                        />
+                    </>
+                )}
+                {category === CATEGORY.COUNTRY && (
+                    <>
+                        <h3>{c('Title').t`Country Configs`}</h3>
+                        <Alert>
+                            {c('Info')
+                                .t`Country Connect configuration files ensure a faster connection to the selected country on average.`}
+                        </Alert>
+                        {isUpgradeRequiredForCountries() && (
+                            <Alert learnMore="https://account.protonvpn.com/dashboard">{c('Info')
+                                .t`ProtonVPN Basic, Plus or Visionary required for Country level connection.`}</Alert>
+                        )}
+                        <ConfigsTable
+                            isUpgradeRequired={isUpgradeRequiredForCountries}
+                            platform={platform}
+                            protocol={protocol}
+                            loading={loading}
+                            servers={countryServers}
+                        />
+                    </>
+                )}
+                {category === CATEGORY.SERVER && (
+                    <>
+                        <h3>{c('Title').t`Server Configs`}</h3>
+                        <Alert>{c('Info').t`Connect to a single server in the country of your choice.`}</Alert>
+                        <ServerConfigs platform={platform} protocol={protocol} loading={loading} servers={allServers} />
+                    </>
+                )}
+                {isUpgradeRequiredForDownloadAll ? (
+                    <Tooltip title={c('Info').t`Plan upgrade required`}>
+                        <Button loading={vpnLoading} disabled>{c('Action').t`Download All Configurations`}</Button>
+                    </Tooltip>
+                ) : (
+                    <Button loading={vpnLoading} onClick={() => downloadAllConfigs()}>{c('Action')
+                        .t`Download All Configurations`}</Button>
+                )}
+            </Block>
+        </>
+    );
+};
+
+export default OpenVPNConfigurationSection;

--- a/containers/vpn/OpenVPNConfigurationSection/OpenVPNConfigurationSection.js
+++ b/containers/vpn/OpenVPNConfigurationSection/OpenVPNConfigurationSection.js
@@ -3,7 +3,6 @@ import { c } from 'ttag';
 import {
     Alert,
     Row,
-    Radio,
     ButtonGroup,
     Group,
     useApiResult,
@@ -14,7 +13,8 @@ import {
     useUser,
     Tooltip,
     useSortedList,
-    useUserVPN
+    useUserVPN,
+    RadioGroup
 } from 'react-components';
 import { queryVPNLogicalServerInfo, getVPNServerConfig } from 'proton-shared/lib/api/vpn';
 import ConfigsTable, { CATEGORY } from './ConfigsTable';
@@ -82,9 +82,6 @@ const OpenVPNConfigurationSection = () => {
         allServers.filter(({ Tier }) => Tier === 1)
     ).map((groups) => minBy(({ Load }) => Number(Load), groups));
 
-    const handleChangePlatform = (platform) => () => setPlatform(platform);
-    const handleChangeProtocol = (protocol) => () => setProtocol(protocol);
-
     const isUpgradeRequiredForSecureCore = () => !userVPN || !hasPaidVPN || isBasic;
     const isUpgradeRequiredForCountries = () => !userVPN || !hasPaidVPN;
     const isUpgradeRequiredForDownloadAll =
@@ -102,58 +99,32 @@ const OpenVPNConfigurationSection = () => {
 
             <h3 className="mt2">{c('Title').t`1. Select platform`}</h3>
             <Row>
-                <Radio
-                    onChange={handleChangePlatform(PLATFORM.MACOS)}
-                    checked={platform === PLATFORM.MACOS}
+                <RadioGroup
                     name="platform"
-                    className="mr2"
-                >{c('Option').t`MacOS`}</Radio>
-                <Radio
-                    onChange={handleChangePlatform(PLATFORM.LINUX)}
-                    checked={platform === PLATFORM.LINUX}
-                    name="platform"
-                    className="mr2"
-                >{c('Option').t`Linux`}</Radio>
-                <Radio
-                    onChange={handleChangePlatform(PLATFORM.WINDOWS)}
-                    checked={platform === PLATFORM.WINDOWS}
-                    name="platform"
-                    className="mr2"
-                >{c('Option').t`Windows`}</Radio>
-                <Radio
-                    onChange={handleChangePlatform(PLATFORM.ANDROID)}
-                    checked={platform === PLATFORM.ANDROID}
-                    name="platform"
-                    className="mr2"
-                >{c('Option').t`Android`}</Radio>
-                <Radio
-                    onChange={handleChangePlatform(PLATFORM.IOS)}
-                    checked={platform === PLATFORM.IOS}
-                    name="platform"
-                    className="mr2"
-                >{c('Option').t`iOS`}</Radio>
-                <Radio
-                    onChange={handleChangePlatform(PLATFORM.ROUTER)}
-                    checked={platform === PLATFORM.ROUTER}
-                    name="platform"
-                    className="mr2"
-                >{c('Option').t`Router`}</Radio>
+                    value={platform}
+                    onChange={setPlatform}
+                    options={[
+                        { value: PLATFORM.MACOS, label: c('Option').t`MacOS` },
+                        { value: PLATFORM.LINUX, label: c('Option').t`Linux` },
+                        { value: PLATFORM.WINDOWS, label: c('Option').t`Windows` },
+                        { value: PLATFORM.ANDROID, label: c('Option').t`Android` },
+                        { value: PLATFORM.IOS, label: c('Option').t`iOS` },
+                        { value: PLATFORM.ROUTER, label: c('Option').t`Router` }
+                    ]}
+                />
             </Row>
 
             <h3 className="mt2">{c('Title').t`2. Select protocol`}</h3>
             <Row>
-                <Radio
-                    onChange={handleChangeProtocol(PROTOCOL.UDP)}
-                    checked={protocol === PROTOCOL.UDP}
+                <RadioGroup
                     name="protocol"
-                    className="mr2"
-                >{c('Option').t`UDP`}</Radio>
-                <Radio
-                    onChange={handleChangeProtocol(PROTOCOL.TCP)}
-                    checked={protocol === PROTOCOL.TCP}
-                    name="protocol"
-                    className="mr2"
-                >{c('Option').t`TCP`}</Radio>
+                    value={protocol}
+                    onChange={setProtocol}
+                    options={[
+                        { value: PROTOCOL.UDP, label: c('Option').t`UDP` },
+                        { value: PROTOCOL.TCP, label: c('Option').t`TCP` }
+                    ]}
+                />
             </Row>
 
             <h3 className="mt2">{c('Title').t`3. Select connection and download`}</h3>

--- a/containers/vpn/OpenVPNConfigurationSection/ServerConfigs.js
+++ b/containers/vpn/OpenVPNConfigurationSection/ServerConfigs.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { isSecureCoreEnabled } from './utils';
+import { groupWith } from 'proton-shared/lib/helpers/array';
+import { Details, Summary, useUser, useUserVPN } from 'react-components';
+import ConfigsTable, { CATEGORY } from './ConfigsTable';
+import Country from './Country';
+
+// TODO: free servers first in list
+const ServerConfigs = ({ servers, ...rest }) => {
+    const groupedServers = groupWith(
+        (a, b) => a.Country === b.Country,
+        servers.filter(({ Features = 0 }) => !isSecureCoreEnabled(Features))
+    );
+
+    const { isBasic, userVPN } = useUserVPN();
+    const { hasPaidVPN } = useUser();
+    const isUpgradeRequired = (server) =>
+        !userVPN || (!hasPaidVPN && server.Tier > 0) || (isBasic && server.Tier === 2);
+
+    return (
+        <div className="mb1-5">
+            {groupedServers.map((group) => {
+                const server = group[0];
+                return (
+                    <Details key={server.Country}>
+                        <Summary>
+                            <div className="ml0-5">
+                                <Country server={group[0]} />
+                            </div>
+                        </Summary>
+                        <div className="p1">
+                            <ConfigsTable
+                                {...rest}
+                                category={CATEGORY.SERVER}
+                                isUpgradeRequired={isUpgradeRequired}
+                                servers={group}
+                            />
+                        </div>
+                    </Details>
+                );
+            })}
+        </div>
+    );
+};
+
+ServerConfigs.propTypes = {
+    servers: PropTypes.arrayOf(
+        PropTypes.shape({
+            ID: PropTypes.string,
+            Country: PropTypes.string,
+            EntryCountry: PropTypes.string,
+            ExitCountry: PropTypes.string,
+            Domain: PropTypes.string,
+            Features: PropTypes.number,
+            Load: PropTypes.number,
+            Tier: PropTypes.number
+        })
+    )
+};
+
+export default ServerConfigs;

--- a/containers/vpn/OpenVPNConfigurationSection/utils.js
+++ b/containers/vpn/OpenVPNConfigurationSection/utils.js
@@ -1,0 +1,6 @@
+import { SERVER_FEATURES } from 'proton-shared/lib/constants';
+
+export const isFeatureOn = (feature) => (features = 0) => !!(features & feature);
+export const isSecureCoreEnabled = isFeatureOn(SERVER_FEATURES.SECURE_CORE);
+export const isP2PEnabled = isFeatureOn(SERVER_FEATURES.P2P);
+export const isTorEnabled = isFeatureOn(SERVER_FEATURES.TOR);

--- a/containers/vpn/ProtonVPNClientsSection/ProtonVPNClientsSection.js
+++ b/containers/vpn/ProtonVPNClientsSection/ProtonVPNClientsSection.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Row, SubTitle } from 'react-components';
+import { c } from 'ttag';
+import VPNClientCard from './VPNClientCard';
+
+const ProtonVPNClientsSection = () => {
+    return (
+        <>
+            <SubTitle>{c('Title').t`ProtonVPN Clients`}</SubTitle>
+            <Row className="flex-autogrid">
+                <VPNClientCard
+                    title="Android"
+                    icon="android"
+                    link="https://play.google.com/store/apps/details?id=com.protonvpn.android"
+                />
+                <VPNClientCard
+                    title="iOS"
+                    icon="apple"
+                    link="https://itunes.apple.com/us/app/protonvpn-fast-secure-vpn/id1437005085"
+                />
+                <VPNClientCard title="Windows" icon="windows" link="https://protonvpn.com/download/" />
+                <VPNClientCard title="MacOS" icon="apple" link="https://protonvpn.com/download/" />
+                <VPNClientCard title="Linux" icon="linux" link="https://protonvpn.com/support/linux-vpn-setup/" />
+            </Row>
+        </>
+    );
+};
+
+export default ProtonVPNClientsSection;

--- a/containers/vpn/ProtonVPNClientsSection/VPNClientCard.js
+++ b/containers/vpn/ProtonVPNClientsSection/VPNClientCard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Bordered, Icon, Button, Block } from 'react-components';
+import { c } from 'ttag';
+
+const VPNClientCard = ({ title, link, icon }) => {
+    return (
+        <div className="aligncenter flex-autogrid-item">
+            <Bordered>
+                <div>
+                    <Icon size={25} name={icon} />
+                </div>
+                <Block>{title}</Block>
+                <a href={link}>
+                    <Button>{c('Action').t`Download`}</Button>
+                </a>
+            </Bordered>
+        </div>
+    );
+};
+
+VPNClientCard.propTypes = {
+    title: PropTypes.string.isRequired,
+    link: PropTypes.string.isRequired,
+    icon: PropTypes.string.isRequired
+};
+
+export default VPNClientCard;

--- a/helpers/countries.js
+++ b/helpers/countries.js
@@ -242,6 +242,9 @@ const COUNTRIES = [
     { value: 'ZW', label: 'Zimbabwe' }
 ];
 
+const countriesByAbbr = COUNTRIES.reduce((list, country) => ({ ...list, [country.value]: country.label }), {});
+
+export const getCountryByAbbr = (abbr) => countriesByAbbr[abbr];
 export const getFullList = () => TOP_COUNTRIES.concat([DEFAULT_SEPARATOR], COUNTRIES);
 export const getList = () => COUNTRIES;
 export const getFirstTop = () => TOP_COUNTRIES[0];

--- a/hooks/useSortedList.js
+++ b/hooks/useSortedList.js
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { SORT_DIRECTION } from 'proton-shared/lib/constants';
+
+/**
+ * Handles sorting logic for lists that are used in sortable tables.
+ *
+ * @param {array} list
+ * @param {{ key: string, direction: string }} [initialConfig]
+ */
+const useSortedList = (list, initialConfig) => {
+    const [config, setConfig] = useState(initialConfig);
+
+    const comparator = (a, b) => {
+        if (a[config.key] < b[config.key]) {
+            return -1;
+        }
+        if (a[config.key] > b[config.key]) {
+            return 1;
+        }
+        return 0;
+    };
+
+    const sortedList = config
+        ? config.direction === SORT_DIRECTION.ASC
+            ? [...list].sort(comparator)
+            : [...list].sort((a, b) => comparator(b, a))
+        : list;
+
+    const toggleSort = (key) => {
+        if (config && key === config.key) {
+            setConfig((config) => ({
+                key,
+                direction: config.direction === SORT_DIRECTION.ASC ? SORT_DIRECTION.DESC : SORT_DIRECTION.ASC
+            }));
+        } else {
+            setConfig({ key, direction: SORT_DIRECTION.ASC });
+        }
+    };
+
+    return { sortedList, toggleSort, sortConfig: config };
+};
+
+/**
+ * Handles sorting logic, when data is async
+ *
+ * @param {{ key: string, direction: string }} [initialConfig]
+ */
+export const useSortedListAsync = (initialConfig) => useSortedList([], initialConfig);
+
+export default useSortedList;

--- a/hooks/useSortedList.js
+++ b/hooks/useSortedList.js
@@ -4,7 +4,7 @@ import { SORT_DIRECTION } from 'proton-shared/lib/constants';
 /**
  * Handles sorting logic for lists that are used in sortable tables.
  *
- * @param {array} list
+ * @param {Array} list
  * @param {{ key: string, direction: string }} [initialConfig]
  */
 const useSortedList = (list, initialConfig) => {

--- a/hooks/useSortedList.test.js
+++ b/hooks/useSortedList.test.js
@@ -1,5 +1,6 @@
 import { renderHook, act } from 'react-hooks-testing-library';
-import useSortedList, { SORT_DIRECTION } from './useSortedList';
+import useSortedList from './useSortedList';
+import { SORT_DIRECTION } from 'proton-shared/lib/constants';
 
 describe('useSortedList hook', () => {
     it('should return sorted list initially if config is provided', () => {

--- a/hooks/useSortedList.test.js
+++ b/hooks/useSortedList.test.js
@@ -1,0 +1,50 @@
+import { renderHook, act } from 'react-hooks-testing-library';
+import useSortedList, { SORT_DIRECTION } from './useSortedList';
+
+describe('useSortedList hook', () => {
+    it('should return sorted list initially if config is provided', () => {
+        const list = [{ t: 2 }, { t: 3 }, { t: 1 }];
+        const { result } = renderHook(() => useSortedList(list, { key: 't', direction: SORT_DIRECTION.DESC }));
+        expect(result.current.sortedList).toEqual([{ t: 3 }, { t: 2 }, { t: 1 }]);
+        expect(result.current.sortConfig).toEqual({ key: 't', direction: SORT_DIRECTION.DESC });
+    });
+
+    it('should not sort initially if no config is provided', () => {
+        const list = [{ t: 2 }, { t: 3 }, { t: 1 }];
+        const { result } = renderHook(() => useSortedList(list));
+        expect(result.current.sortedList).toEqual(list);
+        expect(result.current.sortConfig).toBeUndefined();
+    });
+
+    it('should set initialize sorting config on sort when none was provided', () => {
+        const list = [{ t: 2 }, { t: 3 }, { t: 1 }];
+        const { result } = renderHook(() => useSortedList(list));
+        act(() => result.current.toggleSort('t'));
+        expect(result.current.sortedList).toEqual([{ t: 1 }, { t: 2 }, { t: 3 }]);
+        expect(result.current.sortConfig).toEqual({ key: 't', direction: SORT_DIRECTION.ASC });
+    });
+
+    it('should toggle sort direction for the same key', () => {
+        const list = [{ t: 2 }, { t: 3 }, { t: 1 }];
+        const { result } = renderHook(() => useSortedList(list, { key: 't', direction: SORT_DIRECTION.ASC }));
+        expect(result.current.sortedList).toEqual([{ t: 1 }, { t: 2 }, { t: 3 }]);
+        expect(result.current.sortConfig).toEqual({ key: 't', direction: SORT_DIRECTION.ASC });
+
+        act(() => result.current.toggleSort('t'));
+
+        expect(result.current.sortedList).toEqual([{ t: 3 }, { t: 2 }, { t: 1 }]);
+        expect(result.current.sortConfig).toEqual({ key: 't', direction: SORT_DIRECTION.DESC });
+    });
+
+    it('should change sort key and set direction to ascending for another key', () => {
+        const list = [{ t: 2, k: 'c' }, { t: 3, k: 'b' }, { t: 1, k: 'a' }];
+        const { result } = renderHook(() => useSortedList(list, { key: 't', direction: SORT_DIRECTION.ASC }));
+        expect(result.current.sortedList).toEqual([{ t: 1, k: 'a' }, { t: 2, k: 'c' }, { t: 3, k: 'b' }]);
+        expect(result.current.sortConfig).toEqual({ key: 't', direction: SORT_DIRECTION.ASC });
+
+        act(() => result.current.toggleSort('k'));
+
+        expect(result.current.sortedList).toEqual([{ t: 1, k: 'a' }, { t: 3, k: 'b' }, { t: 2, k: 'c' }]);
+        expect(result.current.sortConfig).toEqual({ key: 'k', direction: SORT_DIRECTION.ASC });
+    });
+});

--- a/index.js
+++ b/index.js
@@ -273,6 +273,7 @@ export { default as useLoading } from './hooks/useLoading';
 export { default as usePlans } from './hooks/usePlans';
 export { default as usePermissions } from './hooks/usePermissions';
 export { nestChildren, classnames } from './helpers/component';
+export { useUserVPN, UserVPNProvider } from './containers/userVPN';
 
 export { default as useCache } from './containers/cache/useCache';
 export { default as CacheProvider } from './containers/cache/Provider';
@@ -291,6 +292,11 @@ export { default as SpamFiltersSection } from './containers/filters/SpamFiltersS
 export { default as FiltersSection } from './containers/filters/FiltersSection';
 export { default as AddFilterModal } from './containers/filters/AddFilterModal';
 export { default as AddEmailToListModal } from './containers/filters/AddEmailToListModal';
+
+export {
+    default as OpenVPNConfigurationSection
+} from './containers/vpn/OpenVPNConfigurationSection/OpenVPNConfigurationSection';
+export { default as ProtonVPNClientsSection } from './containers/vpn/ProtonVPNClientsSection/ProtonVPNClientsSection';
 
 export { default as useUser } from './hooks/useUser';
 export { default as useCachedModelResult } from './hooks/useCachedModelResult';

--- a/index.js
+++ b/index.js
@@ -312,6 +312,7 @@ export { default as useMemberAddresses } from './hooks/useMemberAddresses';
 export { default as useUserKeys } from './hooks/useUserKeys';
 export { default as useAddressesKeys } from './hooks/useAddressesKeys';
 export { default as useOrganizationKey } from './hooks/useOrganizationKey';
+export { default as useSortedList } from './hooks/useSortedList';
 
 export { default as ErrorBoundary } from './containers/app/ErrorBoundary';
 export { default as ProtonApp } from './containers/app/ProtonApp';

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ export { default as RadioCards } from './components/input/RadioCards';
 export { default as useDebounceInput } from './components/input/useDebounceInput';
 export { default as PasswordInput } from './components/input/PasswordInput';
 export { default as Radio } from './components/input/Radio';
+export { default as RadioGroup } from './components/input/RadioGroup';
 export { default as SubTitle } from './components/title/SubTitle';
 export { default as Title } from './components/title/Title';
 export { default as useLoader } from './components/loader/useLoader';

--- a/package.json
+++ b/package.json
@@ -54,14 +54,15 @@
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.0.0",
-    "@testing-library/react": "^8.0.7",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.0",
     "@babel/plugin-transform-runtime": "^7.4.0",
     "@babel/preset-env": "^7.4.1",
     "@babel/preset-react": "^7.0.0",
+    "@testing-library/jest-dom": "^4.0.0",
+    "@testing-library/react": "^8.0.7",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.5.0",
+    "babel-plugin-transform-require-context": "^0.1.1",
     "eslint": "^5.3.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",


### PR DESCRIPTION
Adds:
- Necessary sections for downloads page
- `useSortedList` hook to simplify sorting lists in components
- user vpn info provider - this one I would like some feedback on, would it make sense to always load this data in VPN project?

CI is failing because of a merge required in proton-shared first.