### PR TITLE
Remove wrong default prop in IllustrationPlaceholder

### DIFF
--- a/containers/illustration/IllustrationPlaceholder.js
+++ b/containers/illustration/IllustrationPlaceholder.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const IllustrationPlaceholder = ({ className, title, text = '', url, uppercase, children }) => {
+const IllustrationPlaceholder = ({ className, title, text, url, uppercase, children }) => {
     const info = typeof text === 'string' ? <p>{text}</p> : text;
 
     return (


### PR DESCRIPTION
With `text=''`, if `text` was not specified, the component would display a useless `<p></p>`