### PR TITLE
Fix autoreply long message display

### DIFF
--- a/containers/autoReply/AutoReplyTemplate.js
+++ b/containers/autoReply/AutoReplyTemplate.js
@@ -59,7 +59,7 @@ const AutoReplyTemplate = ({ autoresponder, onEdit }) => {
                     </InfoLine>
                     <InfoLine label={c('Label').t`Timezone`}>{timezone}</InfoLine>
                     <InfoLine plain label={c('Label').t`Message`}>
-                        <div dangerouslySetInnerHTML={{ __html: autoresponder.Message }} />
+                        <div className="cut" dangerouslySetInnerHTML={{ __html: autoresponder.Message }} />
                     </InfoLine>
                 </tbody>
             </table>


### PR DESCRIPTION
Related to this issue: https://github.com/ProtonMail/protonmail-settings/issues/41

- applied `.cut` class to message container, which makes a basic hyphenation of text (class has been updated on Design System here https://github.com/ProtonMail/design-system/commit/266b993731dd545c7592f92f10334af12dd1d757 )

Chrome with no support of `hyphens` (PC mostly):
![image](https://user-images.githubusercontent.com/2578321/62881209-90aed400-bd2f-11e9-9e5a-708219dfd72d.png)
Firefox (supports `hyphens` property, but of course which this test, hyphen dictionnaries go crazy 🎉  ):
![image](https://user-images.githubusercontent.com/2578321/62881296-c489f980-bd2f-11e9-8780-e820d7877463.png)
