### PR TITLE
Fix orderableTableDisplay component

### DIFF
--- a/components/orderableTable/OrderableTableRow.js
+++ b/components/orderableTable/OrderableTableRow.js
@@ -10,7 +10,9 @@ const OrderableTableRow = ({ index, cells, ...rest }) => (
         <TableRow
             cells={[
                 <OrderableHandle key="icon">
-                    <Icon style={{ cursor: 'row-resize' }} name="text-justify" />
+                    <span className="flex">
+                        <Icon className="mtauto mbauto cursor-row-resize" name="text-justify" />
+                    </span>
                 </OrderableHandle>,
                 ...cells
             ]}

--- a/containers/labels/LabelSortableItem.js
+++ b/containers/labels/LabelSortableItem.js
@@ -21,7 +21,7 @@ function LabelItem({ label, onEditLabel, onRemoveLabel, ...rest }) {
                     <Icon
                         name={Exclusive ? 'folder' : 'label'}
                         style={{ fill: Color }}
-                        className="icon-16p flex-item-noshrink mr1"
+                        className="icon-16p flex-item-noshrink mr1 mtauto mbauto"
                     />
                     <span className="ellipsis">{Name}</span>
                 </div>,

--- a/containers/labels/LabelSortableList.js
+++ b/containers/labels/LabelSortableList.js
@@ -16,12 +16,8 @@ function LabelSortableList({ items, onEditLabel, onRemoveLabel, ...rest }) {
                     <th scope="col" className="w45">
                         {c('Settings/labels - table').t`Name`}
                     </th>
-                    <th scope="col" className="w15">
-                        {c('Settings/labels - table').t`Notification`}
-                    </th>
-                    <th scope="col" className="w30">
-                        {c('Settings/labels - table').t`Actions`}
-                    </th>
+                    <th scope="col">{c('Settings/labels - table').t`Notification`}</th>
+                    <th scope="col">{c('Settings/labels - table').t`Actions`}</th>
                 </tr>
             </OrderableTableHeader>
             <OrderableTableBody>


### PR DESCRIPTION
Related to this: https://github.com/ProtonMail/protonmail-settings/issues/57 

- Remove column widths for notifications/actions 
![image](https://user-images.githubusercontent.com/2578321/62933109-c8fef280-bdc1-11e9-9b8d-621b39b1377e.png)
(snap at 150% zoom, click on image to have real display)

Bonus:
- Also fixed vertical alignment of labels/folders/"grab" icon
- Added helper class for cursor instead of inline-styles

![image](https://user-images.githubusercontent.com/2578321/62933044-a40a7f80-bdc1-11e9-8609-8173aa2ff486.png)
