### PR TITLE
Fix 2FA help link

### DIFF
--- a/containers/account/TwoFactorSection.js
+++ b/containers/account/TwoFactorSection.js
@@ -22,7 +22,7 @@ const TwoFactorSection = () => {
             <Row>
                 <Label htmlFor="twoFactorToggle">
                     <span className="mr0-5">{c('Label').t`Two-factor authentication`}</span>
-                    <Info url="https://protonmail.com/support/knowledge-base/single-password" />
+                    <Info url="https://protonmail.com/support/knowledge-base/two-factor-authentication/" />
                 </Label>
                 <Field>
                     <Toggle checked={!!Enabled} id="twoFactorToggle" onChange={handleChange} />


### PR DESCRIPTION
Related to: https://github.com/ProtonMail/protonmail-settings/issues/102

- Fixed link:
![image](https://user-images.githubusercontent.com/2578321/62933836-673f8800-bdc3-11e9-96f7-645cc86278b3.png)


