### PR TITLE
Add missing four placements and fix sorting

### DIFF
--- a/components/popper/utils.test.js
+++ b/components/popper/utils.test.js
@@ -1,0 +1,107 @@
+import { orderPlacements } from './utils';
+
+describe('popper utils', () => {
+    describe('orderPlacements', () => {
+        it('should order bottom-left correctly', () => {
+            expect(orderPlacements('bottom-left')).toEqual([
+                'bottom-left',
+                'bottom',
+                'bottom-right',
+                'left-bottom',
+                'left',
+                'left-top',
+                'top-left',
+                'top',
+                'top-right',
+                'right-bottom',
+                'right',
+                'right-top'
+            ]);
+        });
+
+        it('should order bottom-right correctly', () => {
+            expect(orderPlacements('bottom-right')).toEqual([
+                'bottom-right',
+                'bottom',
+                'bottom-left',
+                'right-bottom',
+                'right',
+                'right-top',
+                'top-right',
+                'top',
+                'top-left',
+                'left-bottom',
+                'left',
+                'left-top'
+            ]);
+        });
+
+        it('should order bottom correctly', () => {
+            expect(orderPlacements('bottom')).toEqual([
+                'bottom',
+                'bottom-left',
+                'bottom-right',
+                'top',
+                'top-left',
+                'top-right',
+                'left-bottom',
+                'right-bottom',
+                'left',
+                'left-top',
+                'right',
+                'right-top'
+            ]);
+        });
+
+        it('should order left-bottom correctly', () => {
+            expect(orderPlacements('left-bottom')).toEqual([
+                'left-bottom',
+                'left',
+                'left-top',
+                'bottom-left',
+                'bottom',
+                'bottom-right',
+                'right-bottom',
+                'right',
+                'right-top',
+                'top-left',
+                'top',
+                'top-right'
+            ]);
+        });
+
+        it('should order left-top correctly', () => {
+            expect(orderPlacements('left-top')).toEqual([
+                'left-top',
+                'left',
+                'left-bottom',
+                'top-left',
+                'top',
+                'top-right',
+                'right-top',
+                'right',
+                'right-bottom',
+                'bottom-left',
+                'bottom',
+                'bottom-right'
+            ]);
+        });
+
+        it('should order top-left correctly', () => {
+            expect(orderPlacements('top-left')).toEqual([
+                'top-left',
+                'top',
+                'top-right',
+                'left-top',
+                'left',
+                'left-bottom',
+                'bottom-left',
+                'bottom',
+                'bottom-right',
+                'right-top',
+                'right',
+                'right-bottom'
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
`design-system`: https://github.com/ProtonMail/design-system/pull/190/files

TIL: `array.sort` works differently in node and browser.

Adds support for `left-bottom`, `left-top`, `right-top`, `right-bottom` placements. And fixes how positions are determined.

As needed for:
![image](https://user-images.githubusercontent.com/944727/62943239-acbf7d80-bde2-11e9-9f51-976cd693cb8c.png)


Wrote tests for the most important placements, might finish tests for all positions later.