### PR TITLE
Remove currentApp prop and use APP_NAME from useConfig

### DIFF
--- a/components/logo/MainLogo.js
+++ b/components/logo/MainLogo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSubscription, Href } from 'react-components';
+import { useSubscription, Href, useConfig } from 'react-components';
 
 import { formatPlans } from '../../containers/payments/subscription/helpers';
 import { APPS } from 'proton-shared/lib/constants';
@@ -8,26 +8,20 @@ import { APPS } from 'proton-shared/lib/constants';
 import MailLogo from './MailLogo';
 import VpnLogo from './VpnLogo';
 
-const {
-    PROTONMAIL: mail,
-    PROTONCONTACTS: contacts,
-    PROTONDRIVE: drive,
-    PROTONCALENDAR: calendar,
-    PROTONVPN_SETTINGS: vpn,
-    PROTONMAIL_SETTINGS: mailSettings
-} = APPS;
+const { PROTONMAIL, PROTONCONTACTS, PROTONDRIVE, PROTONCALENDAR, PROTONVPN_SETTINGS, PROTONMAIL_SETTINGS } = APPS;
 
-const MainLogo = ({ currentApp, url = 'https://mail.protonmail.com/' }) => {
+const MainLogo = ({ url = 'https://mail.protonmail.com/' }) => {
+    const { APP_NAME } = useConfig();
     const [{ Plans } = {}] = useSubscription();
 
     const { mailPlan = {}, vpnPlan = {} } = formatPlans(Plans);
 
     const logo = (() => {
         // we do not have the proper logos for all the products yet. Use mail logo in the meantime
-        if ([mail, mailSettings, contacts, drive, calendar].includes(currentApp)) {
+        if ([PROTONMAIL, PROTONMAIL_SETTINGS, PROTONCONTACTS, PROTONDRIVE, PROTONCALENDAR].includes(APP_NAME)) {
             return <MailLogo planName={mailPlan.Name} />;
         }
-        if (currentApp === vpn) {
+        if (APP_NAME === PROTONVPN_SETTINGS) {
             return <VpnLogo planName={vpnPlan.Name} />;
         }
         return null;
@@ -41,7 +35,6 @@ const MainLogo = ({ currentApp, url = 'https://mail.protonmail.com/' }) => {
 };
 
 MainLogo.propTypes = {
-    currentApp: PropTypes.oneOf([mail, mailSettings, contacts, calendar, drive, vpn]).isRequired,
     url: PropTypes.string
 };
 

--- a/containers/app/AppsSidebar.js
+++ b/containers/app/AppsSidebar.js
@@ -1,23 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, useUser } from 'react-components';
+import { Icon, useUser, useConfig } from 'react-components';
 import { APPS } from 'proton-shared/lib/constants';
 
 const { PROTONMAIL, PROTONCONTACTS, PROTONCALENDAR, PROTONMAIL_SETTINGS } = APPS;
 
-const AppsSidebar = ({ currentApp = '', items = [] }) => {
+const AppsSidebar = ({ items = [] }) => {
+    const { APP_NAME } = useConfig();
     const [{ isPaid }] = useUser();
     const apps = [
-        { ids: [PROTONMAIL, PROTONMAIL_SETTINGS], icon: 'protonmail', title: 'ProtonMail', link: '/inbox' },
-        isPaid && { ids: [PROTONCALENDAR], icon: 'calendar', title: 'ProtonCalendar', link: '/calendar' },
-        { ids: [PROTONCONTACTS], icon: 'contacts', title: 'ProtonContacts', link: '/contacts' }
+        { appNames: [PROTONMAIL, PROTONMAIL_SETTINGS], icon: 'protonmail', title: 'ProtonMail', link: '/inbox' },
+        isPaid && { appNames: [PROTONCALENDAR], icon: 'calendar', title: 'ProtonCalendar', link: '/calendar' },
+        { appNames: [PROTONCONTACTS], icon: 'contacts', title: 'ProtonContacts', link: '/contacts' }
     ].filter(Boolean);
 
     return (
         <aside className="aside noprint" id="aside-bar">
             <ul className="unstyled m0 aligncenter  flex flex-column h100">
-                {apps.map(({ ids = [], icon, title, link, target }, index) => {
-                    const isCurrent = ids.includes(currentApp);
+                {apps.map(({ appNames = [], icon, title, link, target }, index) => {
+                    const isCurrent = appNames.includes(APP_NAME);
                     const key = `${index}`;
                     return (
                         <li key={key} className="mb0-5">
@@ -46,7 +47,6 @@ const AppsSidebar = ({ currentApp = '', items = [] }) => {
 };
 
 AppsSidebar.propTypes = {
-    currentApp: PropTypes.string,
     items: PropTypes.arrayOf(PropTypes.node)
 };
 

--- a/containers/heading/SupportDropdown.js
+++ b/containers/heading/SupportDropdown.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import { Icon, Dropdown, useModals, BugModal, usePopperAnchor, generateUID } from 'react-components';
+import { Icon, Dropdown, useModals, BugModal, usePopperAnchor, generateUID, useConfig } from 'react-components';
 import { c } from 'ttag';
 import { APPS } from 'proton-shared/lib/constants';
 
@@ -8,13 +7,14 @@ import SupportDropdownButton from './SupportDropdownButton';
 
 const { PROTONVPN_SETTINGS } = APPS;
 
-const SupportDropdown = ({ currentApp = '' }) => {
+const SupportDropdown = () => {
+    const { APP_NAME } = useConfig();
     const { createModal } = useModals();
     const [uid] = useState(generateUID('dropdown'));
     const { anchorRef, isOpen, toggle, close } = usePopperAnchor();
 
     const handleBugReportClick = () => {
-        createModal(<BugModal currentApp={currentApp} />);
+        createModal(<BugModal />);
     };
 
     return (
@@ -26,7 +26,7 @@ const SupportDropdown = ({ currentApp = '' }) => {
                         <a
                             className="w100 flex flex-nowrap color-global-grey nodecoration pt0-5 pb0-5"
                             href={
-                                currentApp === PROTONVPN_SETTINGS
+                                APP_NAME === PROTONVPN_SETTINGS
                                     ? 'https://protonvpn.com/support/'
                                     : 'https://protonmail.com/support/'
                             }
@@ -51,10 +51,6 @@ const SupportDropdown = ({ currentApp = '' }) => {
             </Dropdown>
         </>
     );
-};
-
-SupportDropdown.propTypes = {
-    currentApp: PropTypes.string
 };
 
 export default SupportDropdown;

--- a/containers/heading/UserDropdown.js
+++ b/containers/heading/UserDropdown.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { Link } from 'react-router-dom';
 import {
@@ -14,7 +13,8 @@ import {
     BugModal,
     DonateModal,
     generateUID,
-    PrimaryButton
+    PrimaryButton,
+    useConfig
 } from 'react-components';
 import { revoke } from 'proton-shared/lib/api/auth';
 import { APPS } from 'proton-shared/lib/constants';
@@ -23,7 +23,8 @@ import UserDropdownButton from './UserDropdownButton';
 
 const { PROTONMAIL_SETTINGS, PROTONVPN_SETTINGS } = APPS;
 
-const UserDropdown = ({ currentApp = '', ...rest }) => {
+const UserDropdown = ({ ...rest }) => {
+    const { APP_NAME } = useConfig();
     const api = useApi();
     const [user] = useUser();
     const { DisplayName, Email } = user;
@@ -34,7 +35,7 @@ const UserDropdown = ({ currentApp = '', ...rest }) => {
     const { anchorRef, isOpen, toggle, close } = usePopperAnchor();
 
     const handleBugReportClick = () => {
-        createModal(<BugModal currentApp={currentApp} />);
+        createModal(<BugModal />);
     };
 
     const handleSupportUsClick = () => {
@@ -66,9 +67,9 @@ const UserDropdown = ({ currentApp = '', ...rest }) => {
                             </span>
                         ) : null}
                     </li>
-                    {currentApp === PROTONVPN_SETTINGS ? null : (
+                    {APP_NAME === PROTONVPN_SETTINGS ? null : (
                         <li className="dropDown-item pl1 pr1">
-                            {currentApp === PROTONMAIL_SETTINGS ? (
+                            {APP_NAME === PROTONMAIL_SETTINGS ? (
                                 <Link
                                     to="/settings"
                                     className="w100 flex flex-nowrap color-global-grey nodecoration pt0-5 pb0-5"
@@ -91,7 +92,7 @@ const UserDropdown = ({ currentApp = '', ...rest }) => {
                         <a
                             className="w100 flex flex-nowrap color-global-grey nodecoration pt0-5 pb0-5"
                             href={
-                                currentApp === PROTONVPN_SETTINGS
+                                APP_NAME === PROTONVPN_SETTINGS
                                     ? 'https://protonvpn.com/support/'
                                     : 'https://protonmail.com/support/'
                             }
@@ -146,10 +147,6 @@ const UserDropdown = ({ currentApp = '', ...rest }) => {
             </Dropdown>
         </div>
     );
-};
-
-UserDropdown.propTypes = {
-    currentApp: PropTypes.string
 };
 
 export default UserDropdown;

--- a/containers/payments/BillingSection.js
+++ b/containers/payments/BillingSection.js
@@ -44,12 +44,12 @@ const getSubTotal = (plans = []) => {
     }, 0);
 };
 
-const BillingSection = ({ currentApp, permission }) => {
+const BillingSection = ({ permission }) => {
     const i18n = getCyclesI18N();
 
     const { createModal } = useModals();
     const handleOpenGiftCodeModal = () => createModal(<GiftCodeModal />);
-    const handleOpenCreditsModal = () => createModal(<CreditsModal currentApp={currentApp} />);
+    const handleOpenCreditsModal = () => createModal(<CreditsModal />);
     const [{ hasPaidMail, hasPaidVpn, Credit }] = useUser();
     const [
         { Plans = [], Cycle, Currency, CouponCode, Amount, PeriodEnd, isManagedByMozilla } = {},
@@ -268,7 +268,6 @@ const BillingSection = ({ currentApp, permission }) => {
 };
 
 BillingSection.propTypes = {
-    currentApp: PropTypes.string,
     permission: PropTypes.bool
 };
 

--- a/containers/payments/Bitcoin.js
+++ b/containers/payments/Bitcoin.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import { Alert, Price, Button, useApiResult } from 'react-components';
+import { Alert, Price, Button, useApiResult, useConfig } from 'react-components';
 import { createBitcoinPayment } from 'proton-shared/lib/api/payments';
-import { MIN_BITCOIN_AMOUNT, BTC_DONATION_ADDRESS } from 'proton-shared/lib/constants';
+import { MIN_BITCOIN_AMOUNT, BTC_DONATION_ADDRESS, APPS } from 'proton-shared/lib/constants';
 
 import BitcoinQRCode from './BitcoinQRCode';
 import BitcoinDetails from './BitcoinDetails';
 
+const { PROTONVPN_SETTINGS } = APPS;
+
 const Bitcoin = ({ amount, currency, type }) => {
+    const { APP_NAME } = useConfig();
     const { result = {}, request, error = {} } = useApiResult(() => createBitcoinPayment(amount, currency), []);
     const { AmountBitcoin, Address } = result;
     const address = type === 'donation' ? BTC_DONATION_ADDRESS : Address;
@@ -41,7 +44,13 @@ const Bitcoin = ({ amount, currency, type }) => {
                 <Alert>{c('Info')
                     .t`Bitcoin transactions can take some time to be confirmed (up to 24 hours). Once confirmed, we will add credits to your account. After transaction confirmation, you can pay your invoice with the credits.`}</Alert>
             ) : (
-                <Alert learnMore="https://protonmail.com/support/knowledge-base/paying-with-bitcoin">{c('Info')
+                <Alert
+                    learnMore={
+                        APP_NAME === PROTONVPN_SETTINGS
+                            ? 'https://protonvpn.com/support/vpn-bitcoin-payments/'
+                            : 'https://protonmail.com/support/knowledge-base/paying-with-bitcoin'
+                    }
+                >{c('Info')
                     .t`After making your Bitcoin payment, please follow the instructions below to upgrade.`}</Alert>
             )}
         </>

--- a/containers/payments/Cash.js
+++ b/containers/payments/Cash.js
@@ -1,10 +1,18 @@
 import React from 'react';
 import { c } from 'ttag';
-import { Alert } from 'react-components';
+import { Alert, useConfig } from 'react-components';
+import { APPS } from 'proton-shared/lib/constants';
 
-const Cash = () => (
-    <Alert>{c('Info for cash payment method')
-        .t`To pay via Cash, please email us at contact@protonmail.com for instructions.`}</Alert>
-);
+const { PROTONVPN_SETTINGS } = APPS;
+
+const Cash = () => {
+    const { APP_NAME } = useConfig();
+    const email = APP_NAME === PROTONVPN_SETTINGS ? 'contact@protonvpn.com' : 'contact@protonmail.com';
+
+    return (
+        <Alert>{c('Info for cash payment method')
+            .t`To pay via Cash, please email us at ${email} for instructions.`}</Alert>
+    );
+};
 
 export default Cash;

--- a/containers/payments/CreditsModal.js
+++ b/containers/payments/CreditsModal.js
@@ -10,7 +10,8 @@ import {
     useNotifications,
     useApiWithoutResult,
     useEventManager,
-    useApi
+    useApi,
+    useConfig
 } from 'react-components';
 import { buyCredit } from 'proton-shared/lib/api/payments';
 import { DEFAULT_CURRENCY, DEFAULT_CREDITS_AMOUNT, APPS } from 'proton-shared/lib/constants';
@@ -26,9 +27,10 @@ const getCurrenciesI18N = () => ({
     USD: c('Monetary unit').t`Dollar`
 });
 
-const { PROTONVPN_SETTINGS, PROTONMAIL_SETTINGS } = APPS;
+const { PROTONVPN_SETTINGS } = APPS;
 
-const CreditsModal = ({ currentApp = PROTONMAIL_SETTINGS, onClose, ...rest }) => {
+const CreditsModal = ({ onClose, ...rest }) => {
+    const { APP_NAME } = useConfig();
     const api = useApi();
     const { call } = useEventManager();
     const { method, setMethod, parameters, setParameters, canPay, setCardValidity } = usePayment();
@@ -62,7 +64,7 @@ const CreditsModal = ({ currentApp = PROTONMAIL_SETTINGS, onClose, ...rest }) =>
             <Alert>{c('Info').t`Your payment details are protected with TLS encryption and Swiss privacy laws.`}</Alert>
             <Alert
                 learnMore={
-                    currentApp === PROTONVPN_SETTINGS
+                    APP_NAME === PROTONVPN_SETTINGS
                         ? 'https://protonvpn.com/support/vpn-credit-proration/'
                         : 'https://protonmail.com/support/knowledge-base/credit-proration/'
                 }
@@ -95,7 +97,6 @@ const CreditsModal = ({ currentApp = PROTONMAIL_SETTINGS, onClose, ...rest }) =>
 };
 
 CreditsModal.propTypes = {
-    currentApp: PropTypes.string,
     onClose: PropTypes.func
 };
 

--- a/containers/payments/subscription/SubscriptionModal.js
+++ b/containers/payments/subscription/SubscriptionModal.js
@@ -20,7 +20,8 @@ import {
     Label,
     Field,
     Row,
-    Wizard
+    Wizard,
+    useConfig
 } from 'react-components';
 import { DEFAULT_CURRENCY, DEFAULT_CYCLE, APPS } from 'proton-shared/lib/constants';
 import { checkSubscription, subscribe } from 'proton-shared/lib/api/payments';
@@ -38,7 +39,6 @@ import { handle3DS } from '../paymentTokenHelper';
 const { PROTONMAIL_SETTINGS, PROTONVPN_SETTINGS } = APPS;
 
 const SubscriptionModal = ({
-    currentApp = PROTONMAIL_SETTINGS,
     onClose,
     cycle = DEFAULT_CYCLE,
     currency = DEFAULT_CURRENCY,
@@ -46,6 +46,7 @@ const SubscriptionModal = ({
     plansMap = {},
     ...rest
 }) => {
+    const { APP_NAME } = useConfig();
     const api = useApi();
     const [{ hasPaidMail } = {}] = useUser();
     const [{ MaxMembers } = {}] = useOrganization();
@@ -178,7 +179,7 @@ const SubscriptionModal = ({
         });
     }
 
-    if (currentApp === PROTONMAIL_SETTINGS && (plansMap.plus || plansMap.professional)) {
+    if (APP_NAME === PROTONMAIL_SETTINGS && (plansMap.plus || plansMap.professional)) {
         STEPS.unshift({
             title: c('Title').t`Customization`,
             closeIfSubscriptionChange: true,
@@ -224,7 +225,7 @@ const SubscriptionModal = ({
                     <Alert
                         type="warning"
                         learnMore={
-                            currentApp === PROTONVPN_SETTINGS
+                            APP_NAME === PROTONVPN_SETTINGS
                                 ? 'https://protonvpn.com/terms-and-conditions'
                                 : 'https://protonmail.com/terms-and-conditions'
                         }
@@ -289,8 +290,7 @@ SubscriptionModal.propTypes = {
     cycle: PropTypes.number,
     coupon: PropTypes.string,
     currency: PropTypes.string,
-    plansMap: PropTypes.object,
-    currentApp: PropTypes.string
+    plansMap: PropTypes.object
 };
 
 export default SubscriptionModal;

--- a/containers/payments/subscription/SubscriptionSection.js
+++ b/containers/payments/subscription/SubscriptionSection.js
@@ -29,7 +29,7 @@ const getCyclesi18n = () => ({
     [TWO_YEARS]: c('Billing cycle').t`2-year`
 });
 
-const SubscriptionSection = ({ permission, currentApp = '' }) => {
+const SubscriptionSection = ({ permission }) => {
     const [{ hasPaidMail, hasPaidVpn, isPaid }] = useUser();
     const [subscription, loadingSubscription] = useSubscription();
     const { createModal } = useModals();
@@ -91,15 +91,7 @@ const SubscriptionSection = ({ permission, currentApp = '' }) => {
         const cycle = action === 'yearly' ? YEARLY : Cycle;
         const plansMap = isPaid ? toPlanNames(subscription.Plans) : { plus: 1, vpnplus: 1 };
 
-        createModal(
-            <SubscriptionModal
-                currentApp={currentApp}
-                plansMap={plansMap}
-                coupon={coupon}
-                currency={Currency}
-                cycle={cycle}
-            />
-        );
+        createModal(<SubscriptionModal plansMap={plansMap} coupon={coupon} currency={Currency} cycle={cycle} />);
     };
 
     return (
@@ -260,8 +252,7 @@ const SubscriptionSection = ({ permission, currentApp = '' }) => {
 };
 
 SubscriptionSection.propTypes = {
-    permission: PropTypes.bool,
-    currentApp: PropTypes.string
+    permission: PropTypes.bool
 };
 
 export default SubscriptionSection;

--- a/containers/support/BugModal.js
+++ b/containers/support/BugModal.js
@@ -25,9 +25,10 @@ import {
 import AttachScreenshot from './AttachScreenshot';
 import { collectInfo, getClient } from '../../helpers/report';
 
-const { PROTONMAIL, PROTONVPN_SETTINGS } = APPS;
+const { PROTONVPN_SETTINGS } = APPS;
 
-const BugModal = ({ currentApp = PROTONMAIL, onClose, username: Username = '', addresses = [], ...rest }) => {
+const BugModal = ({ onClose, username: Username = '', addresses = [], ...rest }) => {
+    const { APP_NAME } = useConfig();
     const mailTitles = [
         { value: 'Login problem', text: c('Bug category').t`Login problem` },
         { value: 'Sign up problem', text: c('Bug category').t`Sign up problem` },
@@ -57,10 +58,10 @@ const BugModal = ({ currentApp = PROTONMAIL, onClose, username: Username = '', a
         { value: 'Feature request', text: c('Bug category').t`Feature request` }
     ];
 
-    const titles = currentApp === PROTONVPN_SETTINGS ? vpnTitles : mailTitles;
-    const criticalEmail = currentApp === PROTONVPN_SETTINGS ? 'contact@protonvpn.com' : 'security@protonmail.com';
+    const titles = APP_NAME === PROTONVPN_SETTINGS ? vpnTitles : mailTitles;
+    const criticalEmail = APP_NAME === PROTONVPN_SETTINGS ? 'contact@protonvpn.com' : 'security@protonmail.com';
     const clearCacheLink =
-        currentApp === PROTONVPN_SETTINGS
+        APP_NAME === PROTONVPN_SETTINGS
             ? 'https://protonvpn.com/support/clear-browser-cache-cookies/'
             : 'https://protonmail.com/support/knowledge-base/how-to-clean-cache-and-cookies/';
     const { CLIENT_ID, APP_VERSION, CLIENT_TYPE } = useConfig();
@@ -240,7 +241,6 @@ const BugModal = ({ currentApp = PROTONMAIL, onClose, username: Username = '', a
 };
 
 BugModal.propTypes = {
-    currentApp: PropTypes.string,
     onClose: PropTypes.func,
     username: PropTypes.string,
     addresses: PropTypes.array


### PR DESCRIPTION
Since [this change](https://github.com/ProtonMail/proton-pack/commit/3b3a42a51027ffc681a7f4f366e678cff1b50260), the app name is defined in `useConfig` hook. So we don't need to define `currentApp` prop to identify the app context.

Fix https://github.com/ProtonMail/protonvpn-settings/issues/42
Fix https://github.com/ProtonMail/protonvpn-settings/issues/43
Fix https://github.com/ProtonMail/protonvpn-settings/issues/44