### PR TITLE
Fix Username Section alignment

### DIFF
--- a/containers/account/UsernameSection.js
+++ b/containers/account/UsernameSection.js
@@ -10,7 +10,7 @@ const UsernameSection = () => {
             <SubTitle>{c('Title').t`Username`}</SubTitle>
             <Row>
                 <Label>{c('Label').t`Name`}</Label>
-                <Field>
+                <Field className="pt0-5">
                     <strong>{Name}</strong>
                 </Field>
             </Row>


### PR DESCRIPTION
Before :
![image](https://user-images.githubusercontent.com/2578321/63593022-4ccf9080-c5b3-11e9-8cc8-c5fa8b90ade7.png)

After fix:
![image](https://user-images.githubusercontent.com/2578321/63592983-30cbef00-c5b3-11e9-9dfd-f458ba9a6d85.png)

Added helper to get correct alignment.