### PR TITLE
Fix VPNClientCard component

### DIFF
--- a/containers/vpn/ProtonVPNClientsSection/VPNClientCard.js
+++ b/containers/vpn/ProtonVPNClientsSection/VPNClientCard.js
@@ -1,17 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Bordered, Icon, Button, Block, Href } from 'react-components';
+import { Bordered, Icon, Block, Href } from 'react-components';
 import { c } from 'ttag';
 
 const VPNClientCard = ({ title, link, icon }) => {
     return (
-        <Bordered className="ml0-5 mr0-5 aligncenter">
+        <Bordered className="ml0-5 mr0-5 aligncenter relative">
             <div>
                 <Icon size={25} name={icon} />
             </div>
             <Block>{title}</Block>
-            <Href url={link}>
-                <Button>{c('Action').t`Download`}</Button>
+            <Href url={link} className="pm-button increase-surface-click">
+                {c('Action').t`Download`}
+                <span className="sr-only">{title}</span>
             </Href>
         </Bordered>
     );


### PR DESCRIPTION
Fixed some HTML issues on VPN client card component:

- a `button` in a link, no => better applying `pm-button` style to link directly
- added `increase-surface-click` to link and `relative` to block, so the full block is clickable
- added `sr-only` `span` element in link, in order for the links to be vocalized "Download Android", "Download iOS", etc. instead of "download, download, etc."

No visual change: 
![image](https://user-images.githubusercontent.com/2578321/63595361-10069800-c5b9-11e9-974b-ff311a207a74.png)
