### PR TITLE
Fix DropDownButton alignment

### DIFF
--- a/components/dropdown/DropdownButton.js
+++ b/components/dropdown/DropdownButton.js
@@ -7,7 +7,7 @@ const DropdownButton = ({ hasCaret = false, isOpen, children, ...rest }) => {
     return (
         <Button aria-expanded={isOpen} {...rest}>
             <span className="mauto">
-                <span className={hasCaret ? 'mr0-5' : ''}>{children}</span>
+                <span className={hasCaret && children ? 'mr0-5' : ''}>{children}</span>
                 {hasCaret && <DropdownCaret isOpen={isOpen} />}
             </span>
         </Button>


### PR DESCRIPTION
The caret was badly positionned:

![image](https://user-images.githubusercontent.com/2578321/63600229-755f8680-c5c3-11e9-9655-55aa33237825.png)


An empty `span` with `mr0-5` was causing this.

- Fixed it by updating the condition

Snap:
![image](https://user-images.githubusercontent.com/2578321/63600146-4d702300-c5c3-11e9-8515-006706e84557.png)
