### PR TITLE
Update tables with last "action" column

### DIFF
--- a/containers/addresses/AddressesWithMembers.js
+++ b/containers/addresses/AddressesWithMembers.js
@@ -59,7 +59,7 @@ const AddressesWithMembers = ({ match, user, organization }) => {
             {selectedSelf ? (
                 <AddressesWithUser user={user} />
             ) : (
-                <Table>
+                <Table className="pm-simple-table--has-actions">
                     <TableHeader
                         cells={[
                             c('Header for addresses table').t`Address`,

--- a/containers/apps/ProtonMailAppsSection.js
+++ b/containers/apps/ProtonMailAppsSection.js
@@ -22,7 +22,7 @@ const ProtonMailAppsSection = () => {
     return (
         <>
             <SubTitle>ProtonMail apps</SubTitle>
-            <Table>
+            <Table className="pm-simple-table--has-actions">
                 <TableHeader
                     cells={[
                         c('Title for downloads section').t`Platform`,

--- a/containers/domains/DomainsTable.js
+++ b/containers/domains/DomainsTable.js
@@ -10,7 +10,7 @@ import DomainAddresses from './DomainAddresses';
 
 const DomainsTable = ({ domains = [], domainsAddressesMap = {} }) => {
     return (
-        <Table>
+        <Table className="pm-simple-table--has-actions">
             <TableHeader
                 cells={[
                     c('Header for addresses table').t`Domain`,

--- a/containers/invoices/InvoicesSection.js
+++ b/containers/invoices/InvoicesSection.js
@@ -94,7 +94,7 @@ const InvoicesSection = () => {
                     onSelect={onSelect}
                 />
             </Block>
-            <Table>
+            <Table className="pm-simple-table--has-actions">
                 <TableHeader
                     cells={[
                         'ID',

--- a/containers/keys/KeysTable.js
+++ b/containers/keys/KeysTable.js
@@ -21,7 +21,7 @@ const KeysTable = ({ keys = [], onAction }) => {
     });
 
     return (
-        <Table>
+        <Table className="pm-simple-table--has-actions">
             <thead>
                 <tr>{headerCells}</tr>
             </thead>

--- a/containers/keys/reactivateKeys/ReactivateKeysList.js
+++ b/containers/keys/reactivateKeys/ReactivateKeysList.js
@@ -103,7 +103,7 @@ const ReactivateKeysList = ({ loading = false, allKeys, onUpload }) => {
                     autoClick={false}
                 />
             ) : null}
-            <Table>
+            <Table className="pm-simple-table--has-actions">
                 <TableHeader
                     cells={[
                         c('Title header for keys table').t`Email`,

--- a/containers/members/MembersSection.js
+++ b/containers/members/MembersSection.js
@@ -134,7 +134,7 @@ const MembersSection = () => {
                     />
                 </div>
             </Block>
-            <Table>
+            <Table className="pm-simple-table--has-actions">
                 <TableHeader
                     cells={[
                         c('Title header for members table').t`Name`,

--- a/containers/paymentMethods/PaymentMethodsTable.js
+++ b/containers/paymentMethods/PaymentMethodsTable.js
@@ -24,7 +24,7 @@ const PaymentMethodsTable = ({ methods, loading, fetchMethods }) => {
     };
 
     return (
-        <Table>
+        <Table className="pm-simple-table--has-actions">
             <TableHeader
                 cells={[
                     c('Title for payment methods table').t`Method`,

--- a/containers/vpn/OpenVPNConfigurationSection/ConfigsTable.js
+++ b/containers/vpn/OpenVPNConfigurationSection/ConfigsTable.js
@@ -72,7 +72,7 @@ const ConfigsTable = ({ loading, servers = [], platform, protocol, category, isU
     };
 
     return (
-        <Table>
+        <Table className="pm-simple-table--has-actions">
             <thead>
                 <tr>
                     <TableCell className="w50" type="header">


### PR DESCRIPTION
Related to this: https://github.com/ProtonMail/protonmail-settings/issues/108

Design requested that tables with the last column that are containing "action" buttons have this column right-aligned.

Modifier `pm-simple-table--has-actions` for `table` tag has been created in Design System to manage this: https://github.com/ProtonMail/design-system/commit/7e9830669a7e9d23229484d6b13d23c61cbea478

It has been applied to all concerned `table`s.

Example with fix applied:
![image](https://user-images.githubusercontent.com/2578321/63603800-9e374a00-c5ca-11e9-8f44-42248f255772.png)



Fixes: https://github.com/ProtonMail/protonmail-settings/issues/108 