### PR TITLE
Fix info fillColor (primary)

### DIFF
--- a/components/link/Info.js
+++ b/components/link/Info.js
@@ -9,7 +9,7 @@ const wrapTooltip = (children, title) => <Tooltip title={title}>{children}</Tool
 const wrapLink = (children, url) => <Href url={url}>{children}</Href>;
 
 const Info = ({ url, title, ...rest }) => {
-    let children = <Icon className="icon-16p fill-pm-blue" name="info" {...rest} />;
+    let children = <Icon className="icon-16p fill-primary" name="info" {...rest} />;
 
     if (url) {
         children = wrapLink(children, url);


### PR DESCRIPTION
In order to have info colored with primary project color => Updated `fill` class to `fill-primary`.

For ProtonVPN settings, it gives this: 
![image](https://user-images.githubusercontent.com/2578321/63844312-4319a480-c988-11e9-97ff-376d96426e78.png)
