### PR TITLE
Fix navigation icon class

### DIFF
--- a/components/sidebar/NavItem.js
+++ b/components/sidebar/NavItem.js
@@ -10,10 +10,9 @@ const NavItem = ({ type = 'link', link, isActive, text, onClick, icon, list = []
         <span className="flex flex-nowrap flex-items-center">
             {icon && (
                 <Icon
-                    fill="light"
                     name={icon}
                     color={color}
-                    className="flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert"
+                    className="flex-item-noshrink navigation__icon mr0-5 flex-item-centered-vert"
                 />
             )}
             <span className="ellipsis mw100">{text}</span>


### PR DESCRIPTION
The class for icon in navigation was not correct, updated it to `navigation__icon`.

Before:
![image](https://user-images.githubusercontent.com/2578321/63861933-1a0b0b00-c9ac-11e9-99fb-08530ec15ab8.png)


After fix:
![image](https://user-images.githubusercontent.com/2578321/63861901-0a8bc200-c9ac-11e9-919c-f959d38e8305.png)
