### PR TITLE
Add hyphenation class to signature block

### DIFF
--- a/containers/addresses/IdentitySection.js
+++ b/containers/addresses/IdentitySection.js
@@ -89,7 +89,10 @@ const IdentitySection = () => {
             <Row>
                 <Label>{c('Label').t`Signature`}</Label>
                 <Field>
-                    <div className="bordered-container p1" dangerouslySetInnerHTML={{ __html: address.Signature }} />
+                    <div
+                        className="bordered-container break p1"
+                        dangerouslySetInnerHTML={{ __html: address.Signature }}
+                    />
                 </Field>
                 <span className="ml1">
                     <Button className="pm-button--primary" onClick={handleOpenModal}>{c('Action').t`Edit`}</Button>


### PR DESCRIPTION
The signature block was not truncating properly its content:
![image](https://user-images.githubusercontent.com/2578321/64037084-08189c00-cb55-11e9-883b-0e7153a602ee.png)


- added `cut` class (hyphenation)

After:
![image](https://user-images.githubusercontent.com/2578321/64037040-ea4b3700-cb54-11e9-822c-5c1e9bdb1bba.png)
