### PR TITLE
Fix catch-all modal

### DIFF
--- a/containers/domains/CatchAllModal.js
+++ b/containers/domains/CatchAllModal.js
@@ -8,7 +8,6 @@ import AddressesTable from './AddressesTable';
 const CatchAllModal = ({ domain, domainAddresses, onClose, ...rest }) => {
     return (
         <FormModal
-            small
             onClose={onClose}
             close={c('Action').t`Close`}
             title={c('Title').t`Catch all address`}


### PR DESCRIPTION
Catch-all was too small for its contents.

![image](https://user-images.githubusercontent.com/2578321/64038086-81b18980-cb57-11e9-9f3f-67c2b7d295b0.png)


- Used standard modal (removed `small`)

![image](https://user-images.githubusercontent.com/2578321/64038072-7bbba880-cb57-11e9-84ca-0f70d30b0ec0.png)
