### PR TITLE
Fix alert block max width

### DIFF
--- a/components/alert/Alert.js
+++ b/components/alert/Alert.js
@@ -12,7 +12,7 @@ const CLASSES = {
 const Alert = ({ type = 'info', children, learnMore, className }) => {
     return (
         <div className={CLASSES[type].concat(` ${className || ''}`)}>
-            <div>{children}</div>
+            <div className="mw70ch">{children}</div>
             {learnMore ? (
                 <div>
                     <LearnMore url={learnMore} />


### PR DESCRIPTION
Spotted by @emnproton :
> I think the description text that appears under headings should be more narrow on large resolution displays, as that makes the text more readable.

![image](https://user-images.githubusercontent.com/2578321/64040320-0c48b780-cb5d-11e9-8be6-640b03b23007.png)

- Based on UX recommendations, I've added a helper `mw70ch` (70 caracters), which will avoid too long lines



After:
![image](https://user-images.githubusercontent.com/2578321/64040291-00f58c00-cb5d-11e9-9308-0812dea8c8c2.png)
