### PR TITLE
Fix - rwd display of secure core table

### DIFF
--- a/containers/vpn/OpenVPNConfigurationSection/ConfigsTable.js
+++ b/containers/vpn/OpenVPNConfigurationSection/ConfigsTable.js
@@ -75,11 +75,11 @@ const ConfigsTable = ({ loading, servers = [], platform, protocol, category, isU
         <Table className="pm-simple-table--has-actions">
             <thead>
                 <tr>
-                    <TableCell className="w50" type="header">
+                    <TableCell className="w50 onmobile-wauto" type="header">
                         {category === CATEGORY.SERVER ? c('TableHeader').t`Name` : c('TableHeader').t`Country`}
                     </TableCell>
-                    <TableCell className="w30" type="header">{c('TableHeader').t`Status`}</TableCell>
-                    <TableCell className="w20" type="header">{c('TableHeader').t`Action`}</TableCell>
+                    <TableCell className="w30 onmobile-wauto" type="header">{c('TableHeader').t`Status`}</TableCell>
+                    <TableCell className="w20 onmobile-wauto" type="header">{c('TableHeader').t`Action`}</TableCell>
                 </tr>
             </thead>
             <TableBody loading={loading} colSpan={3}>

--- a/containers/vpn/OpenVPNConfigurationSection/LoadIndicator.js
+++ b/containers/vpn/OpenVPNConfigurationSection/LoadIndicator.js
@@ -4,7 +4,7 @@ import { Tooltip } from 'react-components';
 import { c } from 'ttag';
 
 const LoadIndicator = ({ server: { Load = 0 } }) => (
-    <span style={{ minWidth: '5em' }}>
+    <span className="min-w5e nomobile">
         <Tooltip title={c('Info').t`Server load`}>
             <div className="flex inline-flex-vcenter">
                 <div className="load-indicator">


### PR DESCRIPTION
Some small adaptations for mobile:

- hide status
- removed inline-styles
- made column have auto width on mobile


![image](https://user-images.githubusercontent.com/2578321/64165001-6f2f9c80-ce44-11e9-8fdb-091e0918bd96.png)
