### PR TITLE
Change issuer to Proton and remove @protonmail

### DIFF
--- a/containers/account/EnableTwoFactorModal.js
+++ b/containers/account/EnableTwoFactorModal.js
@@ -57,11 +57,12 @@ const EnableTwoFactorModal = (props) => {
 
         const generatedSharedSecret = generateSharedSecret();
         const primaryAddress = addresses.find(({ Keys = [] }) => Keys.length > 0);
-        const identifier = (primaryAddress && primaryAddress.Email) || `${user.Name}@protonmail`;
+        const identifier = (primaryAddress && primaryAddress.Email) || user.Name;
 
         setTotpData({
             uri: getUri({
                 identifier,
+                issuer: 'Proton',
                 sharedSecret: generatedSharedSecret,
                 period: PERIOD,
                 digits: DIGITS,


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-vpn-settings/issues/127

This would change it from:
* A user without any addresses ~~`ProtonMail (bdtst@protonmail.com)`~~ to **`Proton (bdst)`**
* A user with addresses: ~~`ProtonMail (username@protonmail.com)`~~ to **`Proton (username@protonmail.com)`**