### PR TITLE
Review OpenVPN section to use a modal

### DIFF
--- a/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
@@ -1,24 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { SubTitle, Alert, Row, Field, Label, Copy, PrimaryButton, useUserVPN, useModals } from 'react-components';
 import { c } from 'ttag';
 
 import OpenVPNCredentialsModal from './OpenVPNCredentialsModal';
 
 const OpenVPNAccountSection = () => {
-    const { result, fetch: fetchUserVPN } = useUserVPN();
     const { createModal } = useModals();
-    const [credentials, setCredentials] = useState();
-    const { username = '', password = '' } = credentials;
-
-    // VPN Info might not have been loaded yet
-    useEffect(() => {
-        if (result && result.VPN) {
-            setCredentials({
-                username: result.VPN.Name,
-                password: result.VPN.Password
-            });
-        }
-    }, [result]);
+    const { result = {}, fetch: fetchUserVPN } = useUserVPN();
+    const { VPN = {} } = result;
+    const { username = '', password = '' } = VPN;
 
     const handleEditCredentials = () => {
         createModal(<OpenVPNCredentialsModal username={username} password={password} fetchUserVPN={fetchUserVPN} />);
@@ -49,7 +39,7 @@ const OpenVPNAccountSection = () => {
                     <div className="mb1 pt0-5">
                         <strong>{password}</strong>
                     </div>
-                    <PrimaryButton disabled={!credentials} onClick={handleEditCredentials}>{c('Action')
+                    <PrimaryButton disabled={!username || !password} onClick={handleEditCredentials}>{c('Action')
                         .t`Edit credentials`}</PrimaryButton>
                 </Field>
                 <div className="ml1 flex-item-noshrink onmobile-ml0 onmobile-mt0-5">

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
@@ -32,8 +32,8 @@ const OpenVPNAccountSection = () => {
                     .t`Use the following credentials when connecting to ProtonVPN servers without application. Examples use cases include: Tunnelblick on MacOS, OpenVPN on GNU/Linux.
                     Do not use the OpenVPN / IKEv2 credentials in ProtonVPN applications or on the ProtonVPN dashboard.`}
             </Alert>
-            <Row className="mb1-5">
-                <Label htmlFor="openvpn-username">{c('Label').t`OpenVPN / IKEv2 username`}</Label>
+            <Row>
+                <Label>{c('Label').t`OpenVPN / IKEv2 username`}</Label>
                 <Field>
                     <div className="pt0-5">
                         <strong>{username}</strong>
@@ -44,7 +44,7 @@ const OpenVPNAccountSection = () => {
                 </div>
             </Row>
             <Row>
-                <Label htmlFor="openvpn-password">{c('Label').t`OpenVPN / IKEv2 password`}</Label>
+                <Label>{c('Label').t`OpenVPN / IKEv2 password`}</Label>
                 <Field>
                     <div className="mb1 pt0-5">
                         <strong>{password}</strong>

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
@@ -7,8 +7,8 @@ import OpenVPNCredentialsModal from './OpenVPNCredentialsModal';
 const OpenVPNAccountSection = () => {
     const { result, fetch: fetchUserVPN } = useUserVPN();
     const { createModal } = useModals();
-    const [credentials, setCredentials] = useState({ username: '', password: '' });
-    const { username, password } = credentials;
+    const [credentials, setCredentials] = useState();
+    const { username = '', password = '' } = credentials;
 
     // VPN Info might not have been loaded yet
     useEffect(() => {

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNAccountSection.js
@@ -1,27 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import {
-    SubTitle,
-    Alert,
-    Row,
-    Field,
-    Input,
-    Label,
-    Copy,
-    PrimaryButton,
-    PasswordInput,
-    useUserVPN
-} from 'react-components';
+import { SubTitle, Alert, Row, Field, Label, Copy, PrimaryButton, useUserVPN, useModals } from 'react-components';
 import { c } from 'ttag';
-import useApiWithoutResult from '../../../hooks/useApiWithoutResult';
-import { updateVPNName, updateVPNPassword } from 'proton-shared/lib/api/vpn';
-import useNotifications from '../../notifications/useNotifications';
+
+import OpenVPNCredentialsModal from './OpenVPNCredentialsModal';
 
 const OpenVPNAccountSection = () => {
-    const { createNotification } = useNotifications();
     const { result, fetch: fetchUserVPN } = useUserVPN();
+    const { createModal } = useModals();
     const [credentials, setCredentials] = useState({ username: '', password: '' });
-    const { loading: loadingUsername, request: updateUsername } = useApiWithoutResult(updateVPNName);
-    const { loading: loadingPassword, request: updatePassword } = useApiWithoutResult(updateVPNPassword);
+    const { username, password } = credentials;
 
     // VPN Info might not have been loaded yet
     useEffect(() => {
@@ -33,20 +20,8 @@ const OpenVPNAccountSection = () => {
         }
     }, [result]);
 
-    const { username, password } = credentials;
-
-    const handleChangeUsername = ({ target }) => setCredentials((prev) => ({ ...prev, username: target.value }));
-    const handleChangePassword = ({ target }) => setCredentials((prev) => ({ ...prev, password: target.value }));
-
-    const handleUpdateUsername = async () => {
-        await updateUsername(credentials.username);
-        createNotification({ text: c('Notification').t`OpenVPN username updated` });
-        fetchUserVPN();
-    };
-    const handleUpdatePassword = async () => {
-        await updatePassword(credentials.password);
-        createNotification({ text: c('Notification').t`OpenVPN password updated` });
-        fetchUserVPN();
+    const handleEditCredentials = () => {
+        createModal(<OpenVPNCredentialsModal username={username} password={password} fetchUserVPN={fetchUserVPN} />);
     };
 
     return (
@@ -60,20 +35,8 @@ const OpenVPNAccountSection = () => {
             <Row className="mb1-5">
                 <Label htmlFor="openvpn-username">{c('Label').t`OpenVPN / IKEv2 username`}</Label>
                 <Field>
-                    <div className="mb0-5">
-                        <Input
-                            id="openvpn-username"
-                            autoComplete="off"
-                            value={username}
-                            onChange={handleChangeUsername}
-                        />
-                    </div>
-                    <div>
-                        <PrimaryButton
-                            disabled={!credentials || !credentials.username}
-                            loading={loadingUsername}
-                            onClick={handleUpdateUsername}
-                        >{c('Action').t`Change username`}</PrimaryButton>
+                    <div className="pt0-5">
+                        <strong>{username}</strong>
                     </div>
                 </Field>
                 <div className="ml1 flex-item-noshrink onmobile-ml0 onmobile-mt0-5">
@@ -83,21 +46,11 @@ const OpenVPNAccountSection = () => {
             <Row>
                 <Label htmlFor="openvpn-password">{c('Label').t`OpenVPN / IKEv2 password`}</Label>
                 <Field>
-                    <div className="mb0-5">
-                        <PasswordInput
-                            id="openvpn-password"
-                            autoComplete="off"
-                            value={password}
-                            onChange={handleChangePassword}
-                        />
+                    <div className="mb1 pt0-5">
+                        <strong>{password}</strong>
                     </div>
-                    <div>
-                        <PrimaryButton
-                            disabled={!credentials || !credentials.password}
-                            loading={loadingPassword}
-                            onClick={handleUpdatePassword}
-                        >{c('Action').t`Change password`}</PrimaryButton>
-                    </div>
+                    <PrimaryButton disabled={!credentials} onClick={handleEditCredentials}>{c('Action')
+                        .t`Edit credentials`}</PrimaryButton>
                 </Field>
                 <div className="ml1 flex-item-noshrink onmobile-ml0 onmobile-mt0-5">
                     <Copy value={password} />

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import {
+    FormModal,
+    Row,
+    Label,
+    Field,
+    Input,
+    PasswordInput,
+    useLoading,
+    useNotifications,
+    useApi
+} from 'react-components';
+import { updateVPNName, updateVPNPassword } from 'proton-shared/lib/api/vpn';
+
+const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, ...rest }) => {
+    const [loading, withLoading] = useLoading();
+    const api = useApi();
+    const { createNotification } = useNotifications();
+    const [credentials, setCredentials] = useState({ username, password });
+    const title = c('Title').t`Edit OpenVPN credentials`;
+
+    const handleChangeUsername = ({ target }) => setCredentials((prev) => ({ ...prev, username: target.value }));
+    const handleChangePassword = ({ target }) => setCredentials((prev) => ({ ...prev, password: target.value }));
+
+    const handleSubmit = async () => {
+        await api(updateVPNName(credentials.username));
+        await api(updateVPNPassword(credentials.password));
+        fetchUserVPN();
+        rest.onClose();
+        createNotification({ text: c('Notification').t`OpenVPN credentials updated` });
+    };
+
+    return (
+        <FormModal
+            loading={loading}
+            title={title}
+            close={c('Action').t`Cancel`}
+            submit={c('Action').t`Update`}
+            onSubmit={() => withLoading(handleSubmit())}
+            {...rest}
+        >
+            <Row>
+                <Label htmlFor="openvpn-username">{c('Label').t`OpenVPN / IKEv2 username`}</Label>
+                <Field>
+                    <Input
+                        id="openvpn-username"
+                        autoComplete="off"
+                        value={credentials.username}
+                        onChange={handleChangeUsername}
+                    />
+                </Field>
+            </Row>
+            <Row>
+                <Label htmlFor="openvpn-password">{c('Label').t`OpenVPN / IKEv2 password`}</Label>
+                <Field>
+                    <PasswordInput
+                        id="openvpn-password"
+                        autoComplete="off"
+                        value={credentials.password}
+                        onChange={handleChangePassword}
+                    />
+                </Field>
+            </Row>
+        </FormModal>
+    );
+};
+
+OpenVPNCredentialsModal.propTypes = {
+    username: PropTypes.string,
+    password: PropTypes.string,
+    fetchUserVPN: PropTypes.func.isRequired
+};
+
+export default OpenVPNCredentialsModal;

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -39,6 +39,7 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
             close={c('Action').t`Cancel`}
             submit={c('Action').t`Update`}
             onSubmit={() => withLoading(handleSubmit())}
+            small={true}
             {...rest}
         >
             <Row>

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -50,6 +50,7 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
                         autoComplete="off"
                         value={credentials.username}
                         onChange={handleChangeUsername}
+                        required
                     />
                 </Field>
             </Row>
@@ -61,6 +62,7 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
                         autoComplete="off"
                         value={credentials.password}
                         onChange={handleChangePassword}
+                        required
                     />
                 </Field>
             </Row>

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -27,7 +27,7 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
     const handleSubmit = async () => {
         await api(updateVPNName(credentials.username));
         await api(updateVPNPassword(credentials.password));
-        fetchUserVPN();
+        await fetchUserVPN();
         rest.onClose();
         createNotification({ text: c('Notification').t`OpenVPN / IKEv2 credentials updated` });
     };

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -19,17 +19,17 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
     const api = useApi();
     const { createNotification } = useNotifications();
     const [credentials, setCredentials] = useState({ username, password });
-    const title = c('Title').t`Edit OpenVPN credentials`;
+    const title = c('Title').t`Edit OpenVPN / IKEv2 credentials`;
 
-    const handleChangeUsername = ({ target }) => setCredentials((prev) => ({ ...prev, username: target.value }));
-    const handleChangePassword = ({ target }) => setCredentials((prev) => ({ ...prev, password: target.value }));
+    const handleChangeUsername = ({ target }) => setCredentials({ ...credentials, username: target.value });
+    const handleChangePassword = ({ target }) => setCredentials({ ...credentials, password: target.value });
 
     const handleSubmit = async () => {
         await api(updateVPNName(credentials.username));
         await api(updateVPNPassword(credentials.password));
         fetchUserVPN();
         rest.onClose();
-        createNotification({ text: c('Notification').t`OpenVPN credentials updated` });
+        createNotification({ text: c('Notification').t`OpenVPN / IKEv2 credentials updated` });
     };
 
     return (


### PR DESCRIPTION
Update OpenVPN structure to use a modal when we want to edit credentials.

<img width="717" alt="Capture d’écran 2019-09-06 à 13 56 44" src="https://user-images.githubusercontent.com/1345786/64426193-3eeb3680-d0ae-11e9-931b-77b57da9e2f6.png">
<img width="888" alt="Capture d’écran 2019-09-06 à 13 57 09" src="https://user-images.githubusercontent.com/1345786/64426194-3f83cd00-d0ae-11e9-945f-e7d09165ecb5.png">

Fix https://github.com/ProtonMail/proton-vpn-settings/issues/100