### PR TITLE
Enable download all server configs for free users

### DIFF
--- a/containers/vpn/OpenVPNConfigurationSection/OpenVPNConfigurationSection.js
+++ b/containers/vpn/OpenVPNConfigurationSection/OpenVPNConfigurationSection.js
@@ -91,7 +91,7 @@ const OpenVPNConfigurationSection = () => {
     const isUpgradeRequiredForSecureCore = () => !userVPN || !hasPaidVpn || isBasicVPN;
     const isUpgradeRequiredForCountries = () => !userVPN || !hasPaidVpn;
     const isUpgradeRequiredForDownloadAll =
-        !userVPN || !hasPaidVpn || (isBasicVPN && category === CATEGORY.SECURE_CORE);
+        !userVPN || (!hasPaidVpn && category !== CATEGORY.SERVER) || (isBasicVPN && category === CATEGORY.SECURE_CORE);
 
     return (
         <>


### PR DESCRIPTION
Fixes free user not being able to bulk download server configs. Backend will fix the error where free user is able to download basic configs as well.