### PR TITLE
Fix aligment of icon

### DIFF
--- a/components/input/PasswordInput.js
+++ b/components/input/PasswordInput.js
@@ -37,7 +37,7 @@ const PasswordInput = (props) => {
                     type="button"
                     onClick={toggle}
                 >
-                    <Icon name={type === 'password' ? 'read' : 'unread'} />
+                    <Icon className="mauto" name={type === 'password' ? 'read' : 'unread'} />
                 </button>
             </span>
             <ErrorZone id={uid}>{error && status.isDirty ? error : ''}</ErrorZone>


### PR DESCRIPTION
I've changed a bit the password revealer styles to avoid problems with password managers.

- added class `mauto` on icon

![image](https://user-images.githubusercontent.com/2578321/64429679-ce94e300-d0b6-11e9-8c0e-b651dc06f088.png)
