### PR TITLE
Fix button revealer (noshrink)

### DIFF
--- a/components/input/PasswordInput.js
+++ b/components/input/PasswordInput.js
@@ -32,7 +32,7 @@ const PasswordInput = (props) => {
                 />
                 <button
                     title={type === 'password' ? c('Label').t`Reveal password` : c('Label').t`Hide password`}
-                    className="password-revealer inline-flex"
+                    className="password-revealer inline-flex flex-item-noshrink"
                     disabled={disabled}
                     type="button"
                     onClick={toggle}


### PR DESCRIPTION
- just added `flex-item-noshrink` on the button for responsive display.

![image](https://user-images.githubusercontent.com/2578321/64445858-ad90ba00-d0d7-11e9-8b0f-2c68e8eeea53.png)
