### PR TITLE
Feat - add option to make payment block fluid

### DIFF
--- a/containers/payments/Payment.js
+++ b/containers/payments/Payment.js
@@ -72,7 +72,7 @@ const Payment = ({
         <>
             <Row>
                 <Label>{c('Label').t`Payment method`}</Label>
-                <Field className={classnames([fluidDisplay && 'auto flex-item-fluid-auto'])}>
+                <Field className={fieldClassName}>
                     <div className="mb1">
                         <PaymentMethodsSelect
                             loading={loading}

--- a/containers/payments/Payment.js
+++ b/containers/payments/Payment.js
@@ -114,7 +114,7 @@ Payment.propTypes = {
     onValidCard: PropTypes.func,
     cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.YEARLY, CYCLE.TWO_YEARS]),
     onPay: PropTypes.func,
-    fluidDisplay: PropTypes.bool
+    fieldClassName: PropTypes.string
 };
 
 export default Payment;

--- a/containers/payments/Payment.js
+++ b/containers/payments/Payment.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import { classnames } from '../../helpers/component';
 import { Label, Row, Field, Alert, Price } from 'react-components';
 import { CYCLE, PAYMENT_METHOD_TYPES, MIN_DONATION_AMOUNT, MIN_CREDIT_AMOUNT } from 'proton-shared/lib/constants';
 
@@ -24,7 +23,7 @@ const Payment = ({
     onMethod,
     onValidCard,
     onPay,
-    fluidDisplay
+    fieldClassName
 }) => {
     const { methods, options, loading } = usePaymentMethods({ amount, cycle, coupon, type });
 

--- a/containers/payments/Payment.js
+++ b/containers/payments/Payment.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
+import { classnames } from '../../helpers/component';
 import { Label, Row, Field, Alert, Price } from 'react-components';
 import { CYCLE, PAYMENT_METHOD_TYPES, MIN_DONATION_AMOUNT, MIN_CREDIT_AMOUNT } from 'proton-shared/lib/constants';
 
@@ -22,7 +23,8 @@ const Payment = ({
     method,
     onMethod,
     onValidCard,
-    onPay
+    onPay,
+    fluidDisplay
 }) => {
     const { methods, options, loading } = usePaymentMethods({ amount, cycle, coupon, type });
 
@@ -70,7 +72,7 @@ const Payment = ({
         <>
             <Row>
                 <Label>{c('Label').t`Payment method`}</Label>
-                <Field>
+                <Field className={classnames([fluidDisplay && 'auto flex-item-fluid-auto'])}>
                     <div className="mb1">
                         <PaymentMethodsSelect
                             loading={loading}
@@ -111,7 +113,8 @@ Payment.propTypes = {
     onMethod: PropTypes.func,
     onValidCard: PropTypes.func,
     cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.YEARLY, CYCLE.TWO_YEARS]),
-    onPay: PropTypes.func
+    onPay: PropTypes.func,
+    fluidDisplay: PropTypes.bool
 };
 
 export default Payment;


### PR DESCRIPTION
In order to achieve design for VPN signup, I had to add a property fluidDisplay on payment component, if it is "activated", it adds some classes on the field container.

![image](https://user-images.githubusercontent.com/2578321/64602878-cfcc5580-d3bf-11e9-807d-cb20133f7680.png)

if this is not activated, we have standard behaviour:
![image](https://user-images.githubusercontent.com/2578321/64603064-18840e80-d3c0-11e9-9357-1f9a1f2dfdfb.png)

