### PR TITLE
Fix vertical centering of user Drop down

### DIFF
--- a/containers/heading/UserDropdownButton.js
+++ b/containers/heading/UserDropdownButton.js
@@ -11,7 +11,7 @@ const UserDropdownButton = ({ user, isOpen, buttonRef, ...rest }) => {
     return (
         <button
             type="button"
-            className="inline-flex dropDown-logout-button"
+            className="inline-flex flex-items-center dropDown-logout-button"
             aria-expanded={isOpen}
             ref={buttonRef}
             {...rest}


### PR DESCRIPTION
- Added vertical centering `flex-items-center` class on button


![image](https://user-images.githubusercontent.com/2578321/64612478-3ce9e600-d3d4-11e9-81cf-2c71b7cf15f8.png)

![image](https://user-images.githubusercontent.com/2578321/64612492-42dfc700-d3d4-11e9-9fc8-fa249743b19a.png)

Fixes: https://github.com/ProtonMail/proton-vpn-settings/issues/201