### PR TITLE
Throw in render if a model or api result fails

### DIFF
--- a/components/modal/ModalErrorBoundary.js
+++ b/components/modal/ModalErrorBoundary.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { GenericError } from 'react-components';
+import { PropTypes } from 'prop-types';
+import { traceError } from 'proton-shared/lib/helpers/sentry';
+import { c } from 'ttag';
+
+import FormModal from './FormModal';
+
+class ModalErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(error) {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error, info) {
+        this.props.onError && this.props.onError(error, info);
+        traceError(error);
+        console.error(error);
+    }
+
+    render() {
+        const { children, ...rest } = this.props;
+        if (!this.state.hasError) {
+            return children;
+        }
+        return (
+            <FormModal close={c('Action').t`Close`} title={c('Title').t`Error`} hasSubmit={false} {...rest}>
+                <GenericError className="pt2" />
+            </FormModal>
+        );
+    }
+}
+
+ModalErrorBoundary.propTypes = {
+    children: PropTypes.node,
+    onError: PropTypes.func
+};
+
+export default ModalErrorBoundary;

--- a/containers/modals/Container.js
+++ b/containers/modals/Container.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { OverlayModal } from 'react-components';
 import { withRouter } from 'react-router-dom';
 
+import ModalErrorBoundary from '../../components/modal/ModalErrorBoundary';
+
 const ModalsContainer = ({ modals, removeModal, hideModal, location }) => {
     const [containerIsClosing, setContainerIsClosing] = useState(false);
 
@@ -64,13 +66,18 @@ const ModalsContainer = ({ modals, removeModal, hideModal, location }) => {
             hideModal(id);
         };
 
-        return React.cloneElement(content, {
+        const props = {
             onClose: handleModalClose,
             onExit: handleModalExit,
             isBehind: !isLast,
-            isClosing,
-            key: id
-        });
+            isClosing
+        };
+
+        return (
+            <ModalErrorBoundary key={id} {...props}>
+                {React.cloneElement(content, props)}
+            </ModalErrorBoundary>
+        );
     });
 
     const handleContainerAnimationEnd = () => {

--- a/hooks/useApiResult.js
+++ b/hooks/useApiResult.js
@@ -7,7 +7,11 @@ const useApiResult = (fn, dependencies) => {
     const request = useApi();
     const { loading, result, error, run } = useAsync(true);
 
-    // Either user specified dependencies or empty array to always cancel requests on unmount.
+    if (error) {
+        // Throw in render to allow the error boundary to catch it
+        throw error;
+    }
+
     const hookDependencies = dependencies || [];
 
     // Callback updates

--- a/hooks/useCachedModelResult.js
+++ b/hooks/useCachedModelResult.js
@@ -79,6 +79,11 @@ const useCachedModelResult = (cache, key, miss) => {
     });
     const keyRef = useRef(key);
 
+    if (state && state[2]) {
+        // Throw in render to allow the error boundary to catch it
+        throw new Error(state[2]);
+    }
+
     useEffect(() => {
         const cacheListener = (changedKey) => {
             if (changedKey !== key) {

--- a/hooks/useCachedModelResult.js
+++ b/hooks/useCachedModelResult.js
@@ -81,7 +81,7 @@ const useCachedModelResult = (cache, key, miss) => {
 
     if (state && state[2]) {
         // Throw in render to allow the error boundary to catch it
-        throw new Error(state[2]);
+        throw state[2];
     }
 
     useEffect(() => {


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-vpn-settings/issues/211
Fix https://github.com/ProtonMail/proton-vpn-settings/issues/210

* If a model fails to be fetched, the hook will throw in render
* If a request from `useApiResult` fails to be fetched, the hook will throw in render
* And adds an error boundary to modals
<img width="501" alt="Screenshot 2019-09-11 at 13 35 50" src="https://user-images.githubusercontent.com/352607/64694698-94eb2000-d49a-11e9-98a6-e9025c484fa4.png">
