### PR TITLE
Fix #276 - loader centering

### DIFF
--- a/components/loader/Loader.js
+++ b/components/loader/Loader.js
@@ -15,8 +15,9 @@ const MEDIUM_HEIGHT = '80';
 
 const Loader = ({ size = 'small' }) => {
     return (
-        <div className="center mb2 mt2">
+        <div className="center flex mb2 mt2">
             <img
+                className="mauto"
                 src={IMAGES[size]}
                 width={size === 'medium' ? MEDIUM_WIDTH : undefined}
                 height={size === 'medium' ? MEDIUM_HEIGHT : undefined}


### PR DESCRIPTION
- centered loader using `flex` and `mauto` 

![image](https://user-images.githubusercontent.com/2578321/64731130-dd2d3100-d4e0-11e9-904f-ab1cdf2be580.png)

Fixes: #276 