### PR TITLE
Fix - added modifier class on password container

### DIFF
--- a/components/input/PasswordInput.js
+++ b/components/input/PasswordInput.js
@@ -28,7 +28,7 @@ const PasswordInput = (props) => {
             <span className={classNameContainer}>
                 <input
                     className={`pm-field w100 ${className} ${statusClasses}`}
-                    aria-invalid={error && status.isDirty}
+                     aria-invalid={isInvalid}
                     aria-describedby={uid}
                     type={type}
                     disabled={disabled}


### PR DESCRIPTION
- added a modifier class `password-revealer-container--invalid` coming from Design system
- updated Design system to apply correct styles


![image](https://user-images.githubusercontent.com/2578321/64776572-bdd1ea80-d558-11e9-9430-9178848a2de5.png)


Fixes: https://github.com/ProtonMail/proton-vpn-settings/issues/223