### PR TITLE
Allow URL updates from modals

### DIFF
--- a/containers/modals/Container.js
+++ b/containers/modals/Container.js
@@ -7,6 +7,9 @@ const ModalsContainer = ({ modals, removeModal, hideModal, location }) => {
     const [containerIsClosing, setContainerIsClosing] = useState(false);
 
     useEffect(() => {
+        if (location.state && location.state.ignoreClose) {
+            return;
+        }
         modals.forEach(({ id, content }) => {
             content.props.onClose && content.props.onClose();
             hideModal(id);


### PR DESCRIPTION
Currently any URL change will close any modal that may be open. However, in certain cases (like to fix https://github.com/ProtonMail/proton-contacts/issues/124), an URL update may be requested from inside a modal, which should therefore not close.

Adding a `state` property to `location` this issue can be fixed