### PR TITLE
Fix display of countries on mobile

### DIFF
--- a/components/input/IntlTelInput.scss
+++ b/components/input/IntlTelInput.scss
@@ -1,3 +1,5 @@
+@import "~design-system/_sass/reusable-components/design-system-config";
+
 // Remove selected flag background when dropdown is active
 .intl-tel-input.allow-dropdown .flag-container:hover .selected-flag {
     background-color: transparent;
@@ -10,5 +12,5 @@
     background-color: rgba(0, 0, 0, 0.05);
 }
 .intl-tel-input .country-list .country-name {
-    color: #262a33;
+    color: $pm-global-grey;
 }


### PR DESCRIPTION
- forced `.country-name` text color to be grey.

![image](https://user-images.githubusercontent.com/2578321/64793348-334eb280-d57b-11e9-8ff2-b06a51725e16.png)

Fixes: https://github.com/ProtonMail/proton-vpn-settings/issues/227 