### PR TITLE
Fix - spacing pricing vpn

### DIFF
--- a/components/price/Price.js
+++ b/components/price/Price.js
@@ -12,7 +12,11 @@ const Price = ({ children: amount = 0, currency = '', className = '', divisor = 
     const c = <span className="currency">{CURRENCIES[currency] || currency}</span>;
     const p = value < 0 ? <span className="prefix">-</span> : null;
     const v = <span className="amount">{Math.abs(value)}</span>;
-    const s = suffix ? <span className="suffix ml0-5">{suffix}</span> : null;
+    const s = suffix ? (
+        <span className="plan-price-suffix" data-suffix={suffix}>
+            {suffix}
+        </span>
+    ) : null;
 
     if (currency === 'USD') {
         return (

--- a/components/price/Price.js
+++ b/components/price/Price.js
@@ -12,7 +12,7 @@ const Price = ({ children: amount = 0, currency = '', className = '', divisor = 
     const c = <span className="currency">{CURRENCIES[currency] || currency}</span>;
     const p = value < 0 ? <span className="prefix">-</span> : null;
     const v = <span className="amount">{Math.abs(value)}</span>;
-    const s = suffix ? <span className="suffix">{suffix}</span> : null;
+    const s = suffix ? <span className="suffix ml0-5">{suffix}</span> : null;
 
     if (currency === 'USD') {
         return (


### PR DESCRIPTION
- added `data-suffix` attribute
- added a rule in Design system to add margin when `data-suffix` is not starting by `/` : 

```css
.plan-price-suffix:not([data-suffix^="/"]) {
  margin-left: .5em;
}
```
(no need for space for other cases)

![image](https://user-images.githubusercontent.com/2578321/64865909-b420b380-d63a-11e9-8f59-c335b4f84e6d.png)

![image](https://user-images.githubusercontent.com/2578321/64865921-ba169480-d63a-11e9-9038-5a11a4b1dcae.png)



Fixes: https://github.com/ProtonMail/proton-vpn-settings/issues/241
