### PR TITLE
Fix logo alignment

### DIFF
--- a/components/logo/MailLogo.js
+++ b/components/logo/MailLogo.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const MailLogo = ({ planName = '', className = 'logo' }) => {
+    const logoClasses = classnames([planName === '' && 'logo--withoutPlan', className]);
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={className}
+            className={logoClasses}
             aria-labelledby="logo__title plan"
             width="148"
             height="36"

--- a/components/logo/MainLogo.js
+++ b/components/logo/MainLogo.js
@@ -22,7 +22,7 @@ const { PROTONMAIL, PROTONCONTACTS, PROTONDRIVE, PROTONCALENDAR, PROTONVPN_SETTI
 const MainLogo = ({ url = '/inbox', external = false, className = '' }) => {
     const { APP_NAME } = useConfig();
     const [subscription] = useSubscription();
-    const classNames = `logo-container nodecoration flex-item-centered-vert ${className}`;
+    const classNames = `logo-container nodecoration flex flex-item-centered-vert ${className}`;
     const planName = getPlanName(subscription, APP_NAME === PROTONVPN_SETTINGS ? VPN : MAIL);
 
     const logo = (() => {

--- a/components/sidebar/Sidebar.js
+++ b/components/sidebar/Sidebar.js
@@ -7,7 +7,9 @@ import MainLogo from '../logo/MainLogo';
 const Sidebar = ({ expanded = false, list = [], url = '/account' }) => {
     return (
         <div className="sidebar flex flex-column noprint" data-expanded={expanded}>
-            <MainLogo url={url} className="nodesktop notablet" />
+            <div className="nodesktop notablet">
+                <MainLogo url={url} />
+            </div>
             <nav className="navigation mw100 flex-item-fluid scroll-if-needed mb1">
                 <NavMenu list={list} />
             </nav>


### PR DESCRIPTION
Spotted by design team: the logo was not properly aligned (vertically)

- Added a `flex` helper to center it
- Wrapped "mobile" logo in sidebar in a div (to avoid a conflict between `flex` and `nodesktop/notablet` helpers)
- Added a modifier when plan is empty, in order to apply correct height (to center vertically correctly, otherwise the plan is a bit too high)

Snapshots: (I've zoomed to show the vertical centering)

With plan:
![image](https://user-images.githubusercontent.com/2578321/65166481-1ade0c80-da41-11e9-8cc9-1fc5fdd8e361.png)

Without:
![image](https://user-images.githubusercontent.com/2578321/65166515-26c9ce80-da41-11e9-9a0b-cc87167188a2.png)


