### PR TITLE
Make minChars=0 work intuitively and fix autocompletes with pre-filled values

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -17,6 +17,7 @@ const Autocomplete = ({
     onOpen = noop,
     onClose = noop,
     onHighlight = noop,
+    minChars,
     ...rest
 }) => {
     const [awesomplete, setAwesomplete] = useState();
@@ -36,6 +37,12 @@ const Autocomplete = ({
         onSelect(text.value, text.label);
     };
 
+    const handleFocus = () => {
+        if (inputValue.length >= minChars && awesomplete) {
+            awesomplete.evaluate();
+        }
+    };
+
     const childrenCount = React.Children.count(children);
     const inputStyleModifier = childrenCount > 0 ? 'pm-field--tiny' : '';
     const dropdownListClasses = 'bg-white w100 bordered-container m0 p0';
@@ -43,6 +50,7 @@ const Autocomplete = ({
     useEffect(() => {
         const awesompleteInstance = new Awesomplete(inputRef.current, {
             container: () => containerRef.current,
+            minChars,
             ...rest
         });
 
@@ -67,7 +75,10 @@ const Autocomplete = ({
     useEffect(() => {
         if (awesomplete) {
             awesomplete.list = list;
-            awesomplete.evaluate();
+
+            if (awesomplete.isOpened) {
+                awesomplete.evaluate();
+            }
         }
     }, [awesomplete, list]);
 
@@ -88,6 +99,7 @@ const Autocomplete = ({
                         ref={inputRef}
                         onBlur={handleSubmit}
                         onKeyDown={onKeyDown}
+                        onFocus={handleFocus}
                     />
                 </div>
                 {/* <ul> injected here by awesomplete */}

--- a/components/autocomplete/Autocomplete.test.js
+++ b/components/autocomplete/Autocomplete.test.js
@@ -6,25 +6,45 @@ const rawText = (item) => (_, node) => node.textContent === item;
 
 describe('Autocomplete component', () => {
     it('should not render a list when input is less than minChars', () => {
+        const enteredValue = 't';
         const list = ['test1', 'test2', 'test3'];
-        const { queryByText } = render(<Autocomplete minChars={1} list={list} />);
+        const { queryByText, getByDisplayValue } = render(
+            <Autocomplete minChars={2} list={list} inputValue={enteredValue} />
+        );
+        fireEvent.focus(getByDisplayValue(enteredValue));
+        const listItems = list.map((item) => queryByText(rawText(item)));
+
+        listItems.map((item) => expect(item).toBe(null));
+    });
+
+    it('should not render a list on input without focus', () => {
+        const list = ['test1', 'test2', 'test3'];
+        const { queryByText } = render(<Autocomplete minChars={1} list={list} inputValue="t" />);
         const listItems = list.map((item) => queryByText(rawText(item)));
 
         listItems.map((item) => expect(item).toBe(null));
     });
 
     it('should render a list of string values', () => {
+        const enteredValue = 't';
         const list = ['test1', 'test2', 'test3'];
-        const { getByText } = render(<Autocomplete minChars={1} list={list} inputValue="t" />);
+        const { getByText, getByDisplayValue } = render(
+            <Autocomplete minChars={1} list={list} inputValue={enteredValue} />
+        );
+        fireEvent.focus(getByDisplayValue(enteredValue));
         const listItems = list.map((item) => getByText(rawText(item)));
 
         expect(listItems).toHaveLength(list.length);
     });
 
     it('should render a list of object values', () => {
+        const enteredValue = 't';
         const list = [{ l: 'test1', v: 'T1' }, { l: 'test2', v: 'T2' }];
         const dataMapper = ({ l, v }) => ({ label: l, value: v });
-        const { getByText } = render(<Autocomplete minChars={1} list={list} inputValue="t" data={dataMapper} />);
+        const { getByText, getByDisplayValue } = render(
+            <Autocomplete minChars={1} list={list} inputValue={enteredValue} data={dataMapper} />
+        );
+        fireEvent.focus(getByDisplayValue(enteredValue));
         const listItems = list.map((item) => getByText(rawText(item.l)));
 
         expect(listItems).toHaveLength(list.length);
@@ -33,10 +53,18 @@ describe('Autocomplete component', () => {
     it('should call onSelect when item is selected from the list', () => {
         const onSubmitMock = jest.fn();
         const onSelectMock = jest.fn();
+        const enteredValue = 't';
         const list = ['test1', 'test2', 'test3'];
-        const { getByText } = render(
-            <Autocomplete minChars={1} list={list} inputValue="t" onSubmit={onSubmitMock} onSelect={onSelectMock} />
+        const { getByText, getByDisplayValue } = render(
+            <Autocomplete
+                minChars={1}
+                list={list}
+                inputValue={enteredValue}
+                onSubmit={onSubmitMock}
+                onSelect={onSelectMock}
+            />
         );
+        fireEvent.focus(getByDisplayValue(enteredValue));
         const listItem = getByText(rawText(list[1]));
         fireEvent.click(listItem);
 


### PR DESCRIPTION
BEFORE:

pre-filled values bug:
![image](http://g.recordit.co/PbTGsmUVHH.gif)

minChars=0 bug (known in awesomplete, did a workaround for us):
![image](http://g.recordit.co/nsnlYwhjGe.gif)

fixed both:
![image](http://g.recordit.co/M5uWZw4U0B.gif)
