### PR TITLE
Fix - support drop down caret color on hover

### DIFF
--- a/containers/heading/SupportDropdownButton.js
+++ b/containers/heading/SupportDropdownButton.js
@@ -14,7 +14,7 @@ const SupportDropdownButton = ({ isOpen, buttonRef, ...rest }) => {
         >
             <Icon name="support1" className="flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert fill-white" />
             <span className="navigation-title topnav-linkText mr0-5">{c('Header').t`Support`}</span>
-            <DropdownCaret isOpen={isOpen} className="expand-caret mtauto mbauto" />
+            <DropdownCaret isOpen={isOpen} className="expand-caret topnav-icon mtauto mbauto" />
         </button>
     );
 };


### PR DESCRIPTION
Spotted by design: the caret of the support dropdown button did not have the correct color on hover.

- fixed by adding `topnav-icon` class on it

![image](https://user-images.githubusercontent.com/2578321/65512673-f3bc8a80-ded9-11e9-9c7b-df8f978317df.png)
