### PR TITLE
Extract login screens

### DIFF
--- a/components/logo/MainLogo.js
+++ b/components/logo/MainLogo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useSubscription, Href, useConfig } from 'react-components';
 import { Link } from 'react-router-dom';
 
-import { APPS, PLAN_SERVICES } from 'proton-shared/lib/constants';
+import { APPS, PLAN_SERVICES, CLIENT_TYPES } from 'proton-shared/lib/constants';
 import { getPlanName } from 'proton-shared/lib/helpers/subscription';
 
 import CalendarLogo from './CalendarLogo';
@@ -20,10 +20,10 @@ const { PROTONMAIL, PROTONCONTACTS, PROTONDRIVE, PROTONCALENDAR, PROTONVPN_SETTI
  * @param {Boolean} external true for external link
  */
 const MainLogo = ({ url = '/inbox', external = false, className = '' }) => {
-    const { APP_NAME } = useConfig();
+    const { APP_NAME, CLIENT_TYPE } = useConfig();
     const [subscription] = useSubscription();
     const classNames = `logo-container nodecoration flex flex-item-centered-vert ${className}`;
-    const planName = getPlanName(subscription, APP_NAME === PROTONVPN_SETTINGS ? VPN : MAIL);
+    const planName = getPlanName(subscription, CLIENT_TYPE === CLIENT_TYPES.VPN ? VPN : MAIL);
 
     const logo = (() => {
         // we do not have the proper logos for all the products yet. Use mail logo in the meantime

--- a/containers/app/LoaderPage.js
+++ b/containers/app/LoaderPage.js
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FullLoader, TextLoader, useConfig } from 'react-components';
 import { c } from 'ttag';
-import { APPS } from 'proton-shared/lib/constants';
+import { CLIENT_TYPES } from 'proton-shared/lib/constants';
 
 import './loaderPage.scss';
 
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const LoaderPage = ({ text, color = 'global-light' }) => {
-    const { APP_NAME } = useConfig();
-    const appName = APP_NAME === PROTONVPN_SETTINGS ? 'ProtonVPN' : 'ProtonMail';
+    const { CLIENT_TYPE } = useConfig();
+    const appName = CLIENT_TYPE === VPN ? 'ProtonVPN' : 'ProtonMail';
     return (
         <div className="centered-absolute aligncenter">
             <FullLoader color={color} size={200} />

--- a/containers/heading/SupportDropdown.js
+++ b/containers/heading/SupportDropdown.js
@@ -1,40 +1,52 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import {
     Icon,
     Dropdown,
     useModals,
     AuthenticatedBugModal,
+    useAuthentication,
     usePopperAnchor,
     generateUID,
-    useConfig
+    useConfig,
+    BugModal
 } from 'react-components';
 import { c } from 'ttag';
-import { APPS } from 'proton-shared/lib/constants';
+import { CLIENT_TYPES } from 'proton-shared/lib/constants';
 
 import SupportDropdownButton from './SupportDropdownButton';
 
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
-const SupportDropdown = () => {
-    const { APP_NAME } = useConfig();
+const SupportDropdown = ({ className, content }) => {
+    const { UID } = useAuthentication();
+    const { CLIENT_TYPE } = useConfig();
     const { createModal } = useModals();
     const [uid] = useState(generateUID('dropdown'));
     const { anchorRef, isOpen, toggle, close } = usePopperAnchor();
+    const isAuthenticated = !!UID;
 
     const handleBugReportClick = () => {
-        createModal(<AuthenticatedBugModal />);
+        createModal(isAuthenticated ? <AuthenticatedBugModal /> : <BugModal />);
     };
 
     return (
         <>
-            <SupportDropdownButton aria-describedby={uid} buttonRef={anchorRef} isOpen={isOpen} onClick={toggle} />
+            <SupportDropdownButton
+                className={className}
+                content={content}
+                aria-describedby={uid}
+                buttonRef={anchorRef}
+                isOpen={isOpen}
+                onClick={toggle}
+            />
             <Dropdown id={uid} isOpen={isOpen} anchorRef={anchorRef} onClose={close} originalPlacement="bottom">
                 <ul className="unstyled mt0-5 mb0-5">
                     <li className="dropDown-item pl1 pr1">
                         <a
                             className="w100 flex flex-nowrap color-global-grey nodecoration pt0-5 pb0-5"
                             href={
-                                APP_NAME === PROTONVPN_SETTINGS
+                                CLIENT_TYPE === VPN
                                     ? 'https://protonvpn.com/support/'
                                     : 'https://protonmail.com/support/'
                             }
@@ -59,6 +71,11 @@ const SupportDropdown = () => {
             </Dropdown>
         </>
     );
+};
+
+SupportDropdown.propTypes = {
+    className: PropTypes.string,
+    content: PropTypes.string
 };
 
 export default SupportDropdown;

--- a/containers/heading/SupportDropdownButton.js
+++ b/containers/heading/SupportDropdownButton.js
@@ -3,23 +3,21 @@ import PropTypes from 'prop-types';
 import { Icon, DropdownCaret } from 'react-components';
 import { c } from 'ttag';
 
-const SupportDropdownButton = ({ isOpen, buttonRef, ...rest }) => {
+const SupportDropdownButton = ({ content = c('Header').t`Support`, isOpen, buttonRef, ...rest }) => {
     return (
-        <button
-            type="button"
-            className="topnav-link inline-flex flex-nowrap nodecoration rounded"
-            aria-expanded={isOpen}
-            ref={buttonRef}
-            {...rest}
-        >
-            <Icon name="support1" className="flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert fill-white" />
-            <span className="navigation-title topnav-linkText mr0-5">{c('Header').t`Support`}</span>
+        <button type="button" aria-expanded={isOpen} ref={buttonRef} {...rest}>
+            <Icon
+                name="support1"
+                className="flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert fill-primary"
+            />
+            <span className="navigation-title topnav-linkText mr0-5">{content}</span>
             <DropdownCaret isOpen={isOpen} className="expand-caret topnav-icon mtauto mbauto" />
         </button>
     );
 };
 
 SupportDropdownButton.propTypes = {
+    content: PropTypes.string,
     isOpen: PropTypes.bool,
     buttonRef: PropTypes.object
 };

--- a/containers/heading/UserDropdown.js
+++ b/containers/heading/UserDropdown.js
@@ -17,14 +17,15 @@ import {
     useConfig
 } from 'react-components';
 import { revoke } from 'proton-shared/lib/api/auth';
-import { APPS } from 'proton-shared/lib/constants';
+import { APPS, CLIENT_TYPES } from 'proton-shared/lib/constants';
 
 import UserDropdownButton from './UserDropdownButton';
 
-const { PROTONMAIL_SETTINGS, PROTONVPN_SETTINGS } = APPS;
+const { PROTONMAIL_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const UserDropdown = ({ ...rest }) => {
-    const { APP_NAME } = useConfig();
+    const { APP_NAME, CLIENT_TYPE } = useConfig();
     const api = useApi();
     const [user] = useUser();
     const { DisplayName, Email, Name } = user;
@@ -67,7 +68,7 @@ const UserDropdown = ({ ...rest }) => {
                             </span>
                         ) : null}
                     </li>
-                    {APP_NAME === PROTONVPN_SETTINGS ? null : (
+                    {CLIENT_TYPE === VPN ? null : (
                         <li className="dropDown-item pl1 pr1">
                             {APP_NAME === PROTONMAIL_SETTINGS ? (
                                 <Link
@@ -92,7 +93,7 @@ const UserDropdown = ({ ...rest }) => {
                         <a
                             className="w100 flex flex-nowrap color-global-grey nodecoration pt0-5 pb0-5"
                             href={
-                                APP_NAME === PROTONVPN_SETTINGS
+                                CLIENT_TYPE === VPN
                                     ? 'https://protonvpn.com/support/'
                                     : 'https://protonmail.com/support/'
                             }

--- a/containers/login/ForgotUsernameContainer.js
+++ b/containers/login/ForgotUsernameContainer.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+import { c } from 'ttag';
+import { useApi, useNotifications, useLoading, ForgotUsernameForm, SignInLayout } from 'react-components';
+import { requestUsername } from 'proton-shared/lib/api/reset';
+
+const ForgotUsernameContainer = ({ history }) => {
+    const api = useApi();
+    const [loading, withLoading] = useLoading();
+    const { createNotification } = useNotifications();
+
+    const handleSubmit = async (email) => {
+        await api(requestUsername(email));
+        createNotification({
+            text: c('Success')
+                .t`If you entered a valid notification email we will send you an email with your usernames in the next minute.`
+        });
+        history.push('/login');
+    };
+
+    return (
+        <SignInLayout title={c('Title').t`Log in`}>
+            <h2>{c('Title').t`Forgot your username?`}</h2>
+            <ForgotUsernameForm onSubmit={(data) => withLoading(handleSubmit(data))} loading={loading} />
+        </SignInLayout>
+    );
+};
+
+ForgotUsernameContainer.propTypes = {
+    history: PropTypes.object.isRequired
+};
+
+export default withRouter(ForgotUsernameContainer);

--- a/containers/login/PublicHeader.js
+++ b/containers/login/PublicHeader.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PublicHeader = ({ left, middle, right }) => (
+    <header className="flex-item-noshrink flex flex-items-center noprint mb2">
+        <div className="nomobile flex-item-fluid">{left}</div>
+        <div className="w150p center">{middle}</div>
+        <div className="nomobile flex-item-fluid alignright">{right}</div>
+    </header>
+);
+
+PublicHeader.propTypes = {
+    left: PropTypes.node,
+    middle: PropTypes.node,
+    right: PropTypes.node
+};
+
+export default PublicHeader;

--- a/containers/login/ResetPasswordContainer.js
+++ b/containers/login/ResetPasswordContainer.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { ResetPasswordForm, SignInLayout } from 'react-components';
+
+const ResetPasswordContainer = ({ onLogin }) => {
+    return (
+        <SignInLayout title={c('Title').t`Log in`}>
+            <h2>{c('Title').t`Reset password`}</h2>
+            <ResetPasswordForm onLogin={onLogin} />
+        </SignInLayout>
+    );
+};
+
+ResetPasswordContainer.propTypes = {
+    onLogin: PropTypes.func.isRequired
+};
+
+export default ResetPasswordContainer;

--- a/containers/login/SignInLayout.js
+++ b/containers/login/SignInLayout.js
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { c } from 'ttag';
+import { Title, Href, VpnLogo, MailLogo, FooterDetails, SupportDropdown, useConfig } from 'react-components';
+import { CLIENT_TYPES } from 'proton-shared/lib/constants';
+
+import PublicHeader from './PublicHeader';
+
+const { VPN } = CLIENT_TYPES;
+
+const SignInLayout = ({ children, title }) => {
+    const { CLIENT_TYPE } = useConfig();
+    const isVPN = CLIENT_TYPE === VPN;
+    const staticURL = isVPN ? 'https://protonvpn.com' : 'https://protonmail.com';
+
+    useEffect(() => {
+        document.title = `${title} - ${isVPN ? 'ProtonVPN' : 'ProtonMail'}`;
+    }, []);
+
+    return (
+        <div className="pt1 pb1 pl2 pr2">
+            <PublicHeader
+                left={
+                    <>
+                        <span className="opacity-50">{c('Label').t`Back to:`}</span>{' '}
+                        <Href url={staticURL} className="inbl color-white nodecoration hover-same-color" target="_self">
+                            {staticURL}
+                        </Href>
+                    </>
+                }
+                middle={
+                    <Href url={staticURL} target="_self">
+                        {isVPN ? <VpnLogo className="fill-primary" /> : <MailLogo className="fill-primary" />}
+                    </Href>
+                }
+                right={
+                    <>
+                        <div className="flex flex-justify-end">
+                            <SupportDropdown className="pm-button--primaryborder-dark" />
+                            <Link className="ml1 notablet pm-button--primary" to="/signup">{c('Link')
+                                .t`Sign up for free`}</Link>
+                        </div>
+                    </>
+                }
+            />
+            <Title className="flex-item-noshrink aligncenter color-primary">{title}</Title>
+            <div className="flex-item-fluid flex-item-noshrink flex flex-column flex-nowrap">
+                <div className="flex flex-column flex-nowrap flex-item-noshrink">
+                    <div className="center bg-white color-global-grey mt2 mw40e w100 p2 bordered-container flex-item-noshrink">
+                        {children}
+                    </div>
+                    <p className="aligncenter flex-item-noshrink">
+                        <Link className="bold nodecoration primary-link" to="/signup">{c('Link')
+                            .t`Don't have an account yet? Sign up for free!`}</Link>
+                    </p>
+                </div>
+                <footer className="opacity-50 mtauto flex-item-noshrink aligncenter pb1">
+                    <FooterDetails link={<a href={staticURL}>{isVPN ? 'ProtonVPN.com' : 'ProtonMail.com'}</a>} />
+                </footer>
+            </div>
+        </div>
+    );
+};
+
+SignInLayout.propTypes = {
+    children: PropTypes.node.isRequired,
+    title: PropTypes.string.isRequired
+};
+
+export default SignInLayout;

--- a/containers/paymentMethods/PaymentMethodsSection.js
+++ b/containers/paymentMethods/PaymentMethodsSection.js
@@ -12,16 +12,16 @@ import {
     useConfig
 } from 'react-components';
 import { queryPaymentMethods } from 'proton-shared/lib/api/payments';
-import { APPS } from 'proton-shared/lib/constants';
+import { CLIENT_TYPES } from 'proton-shared/lib/constants';
 
 import EditCardModal from '../payments/EditCardModal';
 import PayPalModal from '../payments/PayPalModal';
 import PaymentMethodsTable from './PaymentMethodsTable';
 
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const PaymentMethodsSection = () => {
-    const { APP_NAME } = useConfig();
+    const { CLIENT_TYPE } = useConfig();
     const [{ isManagedByMozilla } = {}] = useSubscription();
     const { createModal } = useModals();
     const { result = {}, loading, request } = useApiResult(queryPaymentMethods, []);
@@ -49,7 +49,7 @@ const PaymentMethodsSection = () => {
             <SubTitle>{c('Title').t`Payment methods`}</SubTitle>
             <Alert
                 learnMore={
-                    APP_NAME === PROTONVPN_SETTINGS
+                    CLIENT_TYPE === VPN
                         ? 'https://protonvpn.com/support/payment-options/'
                         : 'https://protonmail.com/support/knowledge-base/payment'
                 }

--- a/containers/payments/Bitcoin.js
+++ b/containers/payments/Bitcoin.js
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { Alert, Price, Button, Loader, useConfig, useApi, useLoading } from 'react-components';
 import { createBitcoinPayment } from 'proton-shared/lib/api/payments';
-import { MIN_BITCOIN_AMOUNT, BTC_DONATION_ADDRESS, APPS } from 'proton-shared/lib/constants';
+import { MIN_BITCOIN_AMOUNT, BTC_DONATION_ADDRESS, CLIENT_TYPES } from 'proton-shared/lib/constants';
 
 import BitcoinQRCode from './BitcoinQRCode';
 import BitcoinDetails from './BitcoinDetails';
 
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const Bitcoin = ({ amount, currency, type }) => {
     const api = useApi();
-    const { APP_NAME } = useConfig();
+    const { CLIENT_TYPE } = useConfig();
     const [loading, withLoading] = useLoading();
     const [error, setError] = useState(false);
     const [amountBitcoin, setAmountBitcoin] = useState();
@@ -66,7 +66,7 @@ const Bitcoin = ({ amount, currency, type }) => {
             ) : (
                 <Alert
                     learnMore={
-                        APP_NAME === PROTONVPN_SETTINGS
+                        CLIENT_TYPE === VPN
                             ? 'https://protonvpn.com/support/vpn-bitcoin-payments/'
                             : 'https://protonmail.com/support/knowledge-base/paying-with-bitcoin'
                     }

--- a/containers/payments/Cash.js
+++ b/containers/payments/Cash.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { c } from 'ttag';
 import { Alert, useConfig } from 'react-components';
-import { APPS } from 'proton-shared/lib/constants';
+import { CLIENT_TYPES } from 'proton-shared/lib/constants';
 
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const Cash = () => {
-    const { APP_NAME } = useConfig();
-    const email = APP_NAME === PROTONVPN_SETTINGS ? 'contact@protonvpn.com' : 'contact@protonmail.com';
+    const { CLIENT_TYPE } = useConfig();
+    const email = CLIENT_TYPE === VPN ? 'contact@protonvpn.com' : 'contact@protonmail.com';
 
     return (
         <Alert>{c('Info for cash payment method')

--- a/containers/payments/CreditsModal.js
+++ b/containers/payments/CreditsModal.js
@@ -15,7 +15,7 @@ import {
     useLoading
 } from 'react-components';
 import { buyCredit } from 'proton-shared/lib/api/payments';
-import { DEFAULT_CURRENCY, DEFAULT_CREDITS_AMOUNT, APPS, MIN_CREDIT_AMOUNT } from 'proton-shared/lib/constants';
+import { DEFAULT_CURRENCY, DEFAULT_CREDITS_AMOUNT, CLIENT_TYPES, MIN_CREDIT_AMOUNT } from 'proton-shared/lib/constants';
 
 import PaymentSelector from './PaymentSelector';
 import Payment from './Payment';
@@ -28,11 +28,11 @@ const getCurrenciesI18N = () => ({
     USD: c('Monetary unit').t`Dollar`
 });
 
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const CreditsModal = (props) => {
     const api = useApi();
-    const { APP_NAME } = useConfig();
+    const { CLIENT_TYPE } = useConfig();
     const { call } = useEventManager();
     const { createModal } = useModals();
     const { method, setMethod, parameters, setParameters, canPay, setCardValidity } = usePayment();
@@ -69,7 +69,7 @@ const CreditsModal = (props) => {
             <Alert>{c('Info').t`Your payment details are protected with TLS encryption and Swiss privacy laws.`}</Alert>
             <Alert
                 learnMore={
-                    APP_NAME === PROTONVPN_SETTINGS
+                    CLIENT_TYPE === VPN
                         ? 'https://protonvpn.com/support/vpn-credit-proration/'
                         : 'https://protonmail.com/support/knowledge-base/credit-proration/'
                 }

--- a/containers/payments/subscription/PaymentDetails.js
+++ b/containers/payments/subscription/PaymentDetails.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { Price, Info, useToggle, SmallButton, useConfig } from 'react-components';
-import { CYCLE, APPS } from 'proton-shared/lib/constants';
+import { CYCLE, CLIENT_TYPES } from 'proton-shared/lib/constants';
 import GiftCodeForm from './GiftCodeForm';
 
 const { MONTHLY, YEARLY, TWO_YEARS } = CYCLE;
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const getBillingCycleI18N = () => ({
     [MONTHLY]: c('Info').t`monthly billing`,
@@ -15,7 +15,7 @@ const getBillingCycleI18N = () => ({
 });
 
 const PaymentDetails = ({ check, model, onChange }) => {
-    const { APP_NAME } = useConfig();
+    const { CLIENT_TYPE } = useConfig();
     const { state, toggle } = useToggle();
     const i18n = getBillingCycleI18N();
 
@@ -46,7 +46,7 @@ const PaymentDetails = ({ check, model, onChange }) => {
                         <span className="mr0-5">{c('Label').t`Proration`}</span>
                         <Info
                             url={
-                                APP_NAME === PROTONVPN_SETTINGS
+                                CLIENT_TYPE === VPN
                                     ? 'https://protonvpn.com/support/vpn-credit-proration/'
                                     : 'https://protonmail.com/support/knowledge-base/credit-proration/'
                             }

--- a/containers/payments/subscription/SubscriptionModal.js
+++ b/containers/payments/subscription/SubscriptionModal.js
@@ -20,7 +20,7 @@ import {
     useConfig,
     useModals
 } from 'react-components';
-import { DEFAULT_CURRENCY, DEFAULT_CYCLE, APPS } from 'proton-shared/lib/constants';
+import { DEFAULT_CURRENCY, DEFAULT_CYCLE, CLIENT_TYPES } from 'proton-shared/lib/constants';
 import { checkSubscription, subscribe } from 'proton-shared/lib/api/payments';
 import { toPrice } from 'proton-shared/lib/helpers/string';
 import { getPlans } from 'proton-shared/lib/helpers/subscription';
@@ -34,7 +34,7 @@ import { getCheckParams, toPlanMap, containsSamePlans } from './helpers';
 import { handlePaymentToken } from '../paymentTokenHelper';
 import Upgrading from './Upgrading';
 
-const { PROTONMAIL_SETTINGS } = APPS;
+const { MAIL } = CLIENT_TYPES;
 const ORDER_SUMMARY_ID = 'order-summary';
 
 const SubscriptionModal = ({
@@ -47,7 +47,7 @@ const SubscriptionModal = ({
     step: initialStep = 0,
     ...rest
 }) => {
-    const { APP_NAME } = useConfig();
+    const { CLIENT_TYPE } = useConfig();
     const api = useApi();
     const { createModal } = useModals();
     const [loading, setLoading] = useState(false);
@@ -177,7 +177,7 @@ const SubscriptionModal = ({
         });
     }
 
-    if (APP_NAME === PROTONMAIL_SETTINGS && (plansMap.plus || plansMap.professional)) {
+    if (CLIENT_TYPE === MAIL && (plansMap.plus || plansMap.professional)) {
         STEPS.unshift({
             title: c('Title').t`Customization`,
             submit: c('Action').t`Next`,

--- a/containers/support/BugModal.js
+++ b/containers/support/BugModal.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { reportBug } from 'proton-shared/lib/api/reports';
-import { APPS } from 'proton-shared/lib/constants';
+import { CLIENT_TYPES } from 'proton-shared/lib/constants';
 import { c } from 'ttag';
 import {
     FormModal,
@@ -26,10 +26,11 @@ import {
 import AttachScreenshot from './AttachScreenshot';
 import { collectInfo, getClient } from '../../helpers/report';
 
-const { PROTONVPN_SETTINGS } = APPS;
+const { VPN } = CLIENT_TYPES;
 
 const BugModal = ({ onClose, username: Username = '', location, addresses = [], ...rest }) => {
-    const { APP_NAME } = useConfig();
+    const { CLIENT_ID, APP_VERSION, CLIENT_TYPE } = useConfig();
+
     const mailTitles = [
         { value: 'Login problem', text: c('Bug category').t`Login problem` },
         { value: 'Sign up problem', text: c('Bug category').t`Sign up problem` },
@@ -59,13 +60,12 @@ const BugModal = ({ onClose, username: Username = '', location, addresses = [], 
         { value: 'Feature request', text: c('Bug category').t`Feature request` }
     ];
 
-    const titles = APP_NAME === PROTONVPN_SETTINGS ? vpnTitles : mailTitles;
-    const criticalEmail = APP_NAME === PROTONVPN_SETTINGS ? 'contact@protonvpn.com' : 'security@protonmail.com';
+    const titles = CLIENT_TYPE === VPN ? vpnTitles : mailTitles;
+    const criticalEmail = CLIENT_TYPE === VPN ? 'contact@protonvpn.com' : 'security@protonmail.com';
     const clearCacheLink =
-        APP_NAME === PROTONVPN_SETTINGS
+        CLIENT_TYPE === VPN
             ? 'https://protonvpn.com/support/clear-browser-cache-cookies/'
             : 'https://protonmail.com/support/knowledge-base/how-to-clean-cache-and-cookies/';
-    const { CLIENT_ID, APP_VERSION, CLIENT_TYPE } = useConfig();
     const Client = getClient(CLIENT_ID);
     const { createNotification } = useNotifications();
     const [{ Email = '' } = {}] = addresses;

--- a/index.js
+++ b/index.js
@@ -126,6 +126,10 @@ export { default as OrderableTable } from './components/orderableTable/Orderable
 export { default as OrderableTableHeader } from './components/orderableTable/OrderableTableHeader';
 export { default as OrderableTableBody } from './components/orderableTable/OrderableTableBody';
 export { default as OrderableTableRow } from './components/orderableTable/OrderableTableRow';
+export { default as SignInLayout } from './containers/login/SignInLayout';
+export { default as PublicHeader } from './containers/login/PublicHeader';
+export { default as ResetPasswordContainer } from './containers/login/ResetPasswordContainer';
+export { default as ForgotUsernameContainer } from './containers/login/ForgotUsernameContainer';
 export { default as LoginForm } from './containers/login/LoginForm';
 export { default as ResetPasswordForm } from './containers/resetPassword/ResetPasswordForm';
 export { default as ForgotUsernameForm } from './containers/resetPassword/ForgotUsernameForm';


### PR DESCRIPTION
Allow us to use similar screens for ProtonMail implementations

Details:

- Extract SignInLayout
- Extract ResetPasswordContainer
- Extract ForgotUsernameContainer
- Review PublicHeader
- Review SupportDropdown to support auth/unauth
- Use CLIENT_TYPE instead of APP_NAME

