### PR TITLE
Use ReturnHost value returned by API to compare origin

### DIFF
--- a/containers/login/FooterDetails.js
+++ b/containers/login/FooterDetails.js
@@ -1,17 +1,15 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
 
 const FooterDetails = ({ link }) => {
-    const yearRef = useRef();
+    const currentYear = new Date().getFullYear();
 
-    useEffect(() => {
-        yearRef.current = new Date().getFullYear();
-    }, []);
-
-    return c('Footer').jt`${yearRef.current} ${React.cloneElement(link, {
-        key: 'static-link'
-    })} - Made globally, hosted in Switzerland.`;
+    return (
+        <>
+            {currentYear} {link} - {c('Footer').t`Made globally, hosted in Switzerland.`}
+        </>
+    );
 };
 
 FooterDetails.propTypes = {

--- a/containers/payments/PayPal.js
+++ b/containers/payments/PayPal.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import { Alert, Loader, SmallButton, Price, useApi, useLoading, PrimaryButton, useConfig } from 'react-components';
+import { Alert, Loader, SmallButton, Price, useApi, useLoading, PrimaryButton } from 'react-components';
 import { MIN_PAYPAL_AMOUNT, MAX_PAYPAL_AMOUNT } from 'proton-shared/lib/constants';
 import { createToken } from 'proton-shared/lib/api/payments';
 
@@ -13,9 +13,9 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     const [loadingToken, withLoadingToken] = useLoading();
     const [loadingVerification, withLoadingVerification] = useLoading();
     const [textError, setTextError] = useState('');
-    const [approvalURL, setApprovalURL] = useState();
-    const [token, setToken] = useState();
-    const { SECURE_URL: secureURL } = useConfig();
+    const [ApprovalURL, setApprovalURL] = useState();
+    const [Token, setToken] = useState();
+    const [ReturnHost, setReturnHost] = useState();
 
     const handleCancel = () => {
         abortRef.current && abortRef.current.abort();
@@ -24,8 +24,8 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     const handleClick = async () => {
         try {
             abortRef.current = new AbortController();
-            await process({ Token: token, api, approvalURL, secureURL, signal: abortRef.current.signal });
-            onPay(toParams({ Amount, Currency }, token));
+            await process({ Token, api, ApprovalURL, ReturnHost, signal: abortRef.current.signal });
+            onPay(toParams({ Amount, Currency }, Token));
         } catch (error) {
             // if not coming from API error
             if (error.message && !error.config) {
@@ -35,7 +35,7 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     };
 
     const generateToken = async () => {
-        const { Token, ApprovalURL } = await api(
+        const { Token, ApprovalURL, ReturnHost } = await api(
             createToken({
                 Amount,
                 Currency,
@@ -46,6 +46,7 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
         );
         setApprovalURL(ApprovalURL);
         setToken(Token);
+        setReturnHost(ReturnHost);
     };
 
     useEffect(() => {

--- a/containers/payments/PayPal.js
+++ b/containers/payments/PayPal.js
@@ -13,9 +13,7 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     const [loadingToken, withLoadingToken] = useLoading();
     const [loadingVerification, withLoadingVerification] = useLoading();
     const [textError, setTextError] = useState('');
-    const [ApprovalURL, setApprovalURL] = useState();
-    const [Token, setToken] = useState();
-    const [ReturnHost, setReturnHost] = useState();
+    const modelRef = useRef({});
 
     const handleCancel = () => {
         abortRef.current && abortRef.current.abort();
@@ -24,6 +22,7 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     const handleClick = async () => {
         try {
             abortRef.current = new AbortController();
+            const { Token, ReturnHost, ApprovalURL } = modelRef.current;
             await process({ Token, api, ApprovalURL, ReturnHost, signal: abortRef.current.signal });
             onPay(toParams({ Amount, Currency }, Token));
         } catch (error) {
@@ -44,9 +43,7 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
                 }
             })
         );
-        setApprovalURL(ApprovalURL);
-        setToken(Token);
-        setReturnHost(ReturnHost);
+        modelRef.current = { Token, ApprovalURL, ReturnHost };
     };
 
     useEffect(() => {

--- a/containers/payments/PaymentVerificationModal.js
+++ b/containers/payments/PaymentVerificationModal.js
@@ -148,6 +148,7 @@ PaymentVerificationModal.propTypes = {
     onClose: PropTypes.func.isRequired,
     token: PropTypes.string.isRequired,
     approvalURL: PropTypes.string.isRequired,
+    returnHost: PropTypes.string.isRequired,
     params: PropTypes.object,
     payment: PropTypes.object
 };

--- a/containers/payments/PaymentVerificationModal.js
+++ b/containers/payments/PaymentVerificationModal.js
@@ -8,7 +8,6 @@ import {
     ResetButton,
     useNotifications,
     useApi,
-    useConfig,
     PrimaryButton
 } from 'react-components';
 import { c } from 'ttag';
@@ -26,7 +25,7 @@ const STEPS = {
 
 const PROCESSING_DELAY = 5000;
 
-const PaymentVerificationModal = ({ params, token, approvalURL, onSubmit, payment = {}, ...rest }) => {
+const PaymentVerificationModal = ({ params, token, approvalURL, returnHost, onSubmit, payment = {}, ...rest }) => {
     const TITLES = {
         [STEPS.REDIRECT]: c('Title').t`Payment verification`,
         [STEPS.REDIRECTING]: c('Title').t`Processing...`,
@@ -37,7 +36,6 @@ const PaymentVerificationModal = ({ params, token, approvalURL, onSubmit, paymen
     const [error, setError] = useState({});
     const api = useApi();
     const { createNotification } = useNotifications();
-    const { SECURE_URL: secureURL } = useConfig();
     const abortRef = useRef();
 
     const handleCancel = () => {
@@ -53,7 +51,13 @@ const PaymentVerificationModal = ({ params, token, approvalURL, onSubmit, paymen
                 setStep(STEPS.REDIRECTED);
             }, PROCESSING_DELAY);
             abortRef.current = new AbortController();
-            await process({ Token: token, api, approvalURL, secureURL, signal: abortRef.current.signal });
+            await process({
+                Token: token,
+                api,
+                ReturnHost: returnHost,
+                ApprovalURL: approvalURL,
+                signal: abortRef.current.signal
+            });
             onSubmit(toParams(params, token));
             rest.onClose();
         } catch (error) {

--- a/containers/payments/paymentTokenHelper.js
+++ b/containers/payments/paymentTokenHelper.js
@@ -4,6 +4,7 @@ import { getTokenStatus, createToken } from 'proton-shared/lib/api/payments';
 import { wait } from 'proton-shared/lib/helpers/promise';
 import { c } from 'ttag';
 import { PaymentVerificationModal } from 'react-components';
+import { getHostname } from 'proton-shared/lib/helpers/url';
 
 const {
     STATUS_PENDING,
@@ -63,10 +64,10 @@ const pull = async ({ timer = 0, Token, api, signal }) => {
 
 /**
  * Initialize new tab and listen it
- * @param {String} String
+ * @param {String} Token from API
  * @param {Object} api useApi
- * @param {String} ApprovalURL
- * @param {String} ReturnHost
+ * @param {String} ApprovalURL from API
+ * @param {String} ReturnHost from API
  * @param {AbortSignal} signal instance
  * @returns {Promise}
  */
@@ -101,7 +102,7 @@ export const process = ({ Token, api, ApprovalURL, ReturnHost, signal }) => {
         const onMessage = (event) => {
             const origin = event.origin || event.originalEvent.origin; // For Chrome, the origin property is in the event.originalEvent object.
 
-            if (!origin.includes(ReturnHost)) {
+            if (getHostname(origin) !== getHostname(ReturnHost)) {
                 return;
             }
 

--- a/containers/payments/paymentTokenHelper.js
+++ b/containers/payments/paymentTokenHelper.js
@@ -65,13 +65,13 @@ const pull = async ({ timer = 0, Token, api, signal }) => {
  * Initialize new tab and listen it
  * @param {String} String
  * @param {Object} api useApi
- * @param {String} approvalURL
- * @param {String} secureURL
+ * @param {String} ApprovalURL
+ * @param {String} ReturnHost
  * @param {AbortSignal} signal instance
  * @returns {Promise}
  */
-export const process = ({ Token, api, approvalURL, secureURL, signal }) => {
-    const tab = window.open(approvalURL);
+export const process = ({ Token, api, ApprovalURL, ReturnHost, signal }) => {
+    const tab = window.open(ApprovalURL);
 
     return new Promise((resolve, reject) => {
         let listen = false;
@@ -101,7 +101,7 @@ export const process = ({ Token, api, approvalURL, secureURL, signal }) => {
         const onMessage = (event) => {
             const origin = event.origin || event.originalEvent.origin; // For Chrome, the origin property is in the event.originalEvent object.
 
-            if (origin !== secureURL) {
+            if (!origin.includes(ReturnHost)) {
                 return;
             }
 
@@ -162,7 +162,14 @@ export const handlePaymentToken = async ({ params, api, createModal }) => {
         return params;
     }
 
-    const { Token, Status, ApprovalURL } = await api(createToken({ Payment, Amount, Currency, PaymentMethodID }));
+    const { Token, Status, ApprovalURL, ReturnHost } = await api(
+        createToken({
+            Payment,
+            Amount,
+            Currency,
+            PaymentMethodID
+        })
+    );
 
     if (Status === STATUS_CHARGEABLE) {
         return toParams(params, Token);
@@ -173,6 +180,7 @@ export const handlePaymentToken = async ({ params, api, createModal }) => {
             <PaymentVerificationModal
                 payment={Payment}
                 params={params}
+                returnHost={ReturnHost}
                 approvalURL={ApprovalURL}
                 token={Token}
                 onSubmit={resolve}


### PR DESCRIPTION
Use `ReturnHost` value returned by API to compare origin.
```json
{
    "Code": 1000,
    "Token": "mLN7SpUGz25ol1X5wDoDGOGG",
    "Status": 0,
    "ApprovalURL": "https://hooks.stripe.com/3d_secure_2/hosted?publishable_key=pk_test_FgIybmWSP4xgpBTsUJMFYG1k&setup_intent=seti_1FNGJZKpW9DKy5hnIiHwWvlZ&setup_intent_client_secret=seti_1FNGJZKpW9DKy5hnIiHwWvlZ_secret_Ft2OrbowBdg1WtE7aOOJuRxuMiuh00c&source=src_1FNGJZKpW9DKy5hn7lwfDVIq",
    "ReturnHost": "protonmail.blue/api"
}
```