### PR TITLE
Use classnames helper function

### DIFF
--- a/components/alert/Alert.js
+++ b/components/alert/Alert.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { LearnMore } from 'react-components';
+import { classnames } from '../../helpers/component';
 
 const CLASSES = {
     info: 'mb1 block-info-standard',
@@ -11,7 +12,7 @@ const CLASSES = {
 
 const Alert = ({ type = 'info', children, learnMore, className }) => {
     return (
-        <div className={CLASSES[type].concat(` ${className || ''}`)}>
+        <div className={classnames([CLASSES[type], className])}>
             <div className="mw70ch">{children}</div>
             {learnMore ? (
                 <div>

--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { noop } from 'proton-shared/lib/helpers/function';
 import Awesomplete from 'awesomplete';
 import './Autocomplete.scss';
+import { classnames } from '../../helpers/component';
 
 const Autocomplete = ({
     children,
@@ -83,9 +84,9 @@ const Autocomplete = ({
     }, [awesomplete, list]);
 
     return (
-        <div className={'autocomplete awesomplete w100'.concat(className)} onSubmit={handleSubmit}>
+        <div className={classnames(['autocomplete awesomplete w100', className])} onSubmit={handleSubmit}>
             <div className="autocomplete-container" ref={containerRef}>
-                <div className={`flex pm-field ${inputStyleModifier}`}>
+                <div className={classnames(['flex pm-field', inputStyleModifier])}>
                     {childrenCount > 0 && <div className="flex">{children}</div>}
 
                     <input

--- a/components/autocomplete/AutocompleteSelection.js
+++ b/components/autocomplete/AutocompleteSelection.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../icon/Icon';
+import { classnames } from '../../helpers/component';
 
 const AutocompleteSelection = ({ className, label, onRemove, onLabelChange }) => {
     const editable = !!onLabelChange;
@@ -18,7 +19,7 @@ const AutocompleteSelection = ({ className, label, onRemove, onLabelChange }) =>
     };
 
     return (
-        <div className={`flex bordered-container bg-global-light mr0-5 ${className}`}>
+        <div className={classnames(['flex bordered-container bg-global-light mr0-5', className])}>
             <div
                 className="flex ml0-5 mr0-5 flex-item-centered-vert"
                 onKeyDown={handleKeyDown}

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../icon/Icon';
+import { classnames } from '../../helpers/component';
 
 const Button = ({
     type = 'button',
@@ -22,7 +23,7 @@ const Button = ({
         <button
             role={role}
             disabled={loading ? true : disabled}
-            className={`pm-button ${iconButtonClass} ${className}`}
+            className={classnames(['pm-button', iconButtonClass, className])}
             type={type}
             tabIndex={disabled ? '-1' : tabIndex}
             title={title}

--- a/components/button/ButtonGroup.js
+++ b/components/button/ButtonGroup.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from './Button';
+import { classnames } from '../../helpers/component';
 
 const ButtonGroup = ({ children, className = '', ...rest }) => (
-    <Button className={`pm-group-button ${className}`} {...rest}>
+    <Button className={classnames(['pm-group-button', className])} {...rest}>
         {children}
     </Button>
 );

--- a/components/button/Copy.js
+++ b/components/button/Copy.js
@@ -21,7 +21,7 @@ const Copy = ({ value, className = '' }) => {
         <Button
             onClick={handleClick}
             icon="clipboard"
-            className={classnames([className, copied ? 'copied' : ''])}
+            className={classnames([className, copied && 'copied'])}
             title={copied ? c('Label').t`Copied` : c('Label').t`Copy`}
         />
     );

--- a/components/button/Copy.js
+++ b/components/button/Copy.js
@@ -4,6 +4,7 @@ import { c } from 'ttag';
 
 import { textToClipboard } from 'proton-shared/lib/helpers/browser';
 import { Button } from '../button';
+import { classnames } from '../../helpers/component';
 
 const Copy = ({ value, className = '' }) => {
     const [copied, setCopied] = useState(false);
@@ -20,7 +21,7 @@ const Copy = ({ value, className = '' }) => {
         <Button
             onClick={handleClick}
             icon="clipboard"
-            className={`${className} ${copied ? 'copied' : ''}`}
+            className={classnames([className, copied ? 'copied' : ''])}
             title={copied ? c('Label').t`Copied` : c('Label').t`Copy`}
         />
     );

--- a/components/button/ErrorButton.js
+++ b/components/button/ErrorButton.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../icon/Icon';
 import Button from './Button';
+import { classnames } from '../../helpers/component';
 
 const ErrorButton = ({ children, className = '', icon, ...rest }) => {
     const buttonIcon = typeof icon === 'string' ? <Icon name={icon} fill="light" /> : icon;
 
     return (
-        <Button icon={buttonIcon} className={`pm-button--error ${className}`} {...rest}>
+        <Button icon={buttonIcon} className={classnames(['pm-button--error', className])} {...rest}>
             {children}
         </Button>
     );

--- a/components/button/Group.js
+++ b/components/button/Group.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
-const Group = ({ children, className = '' }) => <div className={`pm-group-buttons ${className}`}>{children}</div>;
+const Group = ({ children, className = '' }) => (
+    <div className={classnames(['pm-group-buttons', className])}>{children}</div>
+);
 
 Group.propTypes = {
     children: PropTypes.node.isRequired,

--- a/components/button/InlineLinkButton.js
+++ b/components/button/InlineLinkButton.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const InlineLinkButton = ({ children, className = '', ...rest }) => {
     return (
-        <button type="button" role="button" className={`link alignbaseline ${className}`} {...rest}>
+        <button type="button" role="button" className={classnames(['link alignbaseline', className])} {...rest}>
             {children}
         </button>
     );

--- a/components/button/LargeButton.js
+++ b/components/button/LargeButton.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from './Button';
+import { classnames } from '../../helpers/component';
 
 const LargeButton = ({ children, className = '', ...rest }) => {
     return (
-        <Button className={`pm-button--large ${className}`} {...rest}>
+        <Button className={classnames(['pm-button--large', className])} {...rest}>
             {children}
         </Button>
     );

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from './Button';
+import { classnames } from '../../helpers/component';
 
 const LinkButton = ({ children, className = '', ...rest }) => {
     return (
-        <Button className={`pm-button--link ${className}`} {...rest}>
+        <Button className={classnames(['pm-button--link', className])} {...rest}>
             {children}
         </Button>
     );

--- a/components/button/PrimaryButton.js
+++ b/components/button/PrimaryButton.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../icon/Icon';
 import Button from './Button';
+import { classnames } from '../../helpers/component';
 
 const PrimaryButton = ({ children, className = '', icon, ...rest }) => {
     const buttonIcon = typeof icon === 'string' ? <Icon name={icon} fill="light" /> : icon;
 
     return (
-        <Button icon={buttonIcon} className={`pm-button--primary ${className}`} {...rest}>
+        <Button icon={buttonIcon} className={classnames(['pm-button--primary', className])} {...rest}>
             {children}
         </Button>
     );

--- a/components/button/SmallButton.js
+++ b/components/button/SmallButton.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from './Button';
+import { classnames } from '../../helpers/component';
 
 const SmallButton = ({ children, className = '', ...rest }) => {
     return (
-        <Button className={`pm-button--small ${className}`} {...rest}>
+        <Button className={classnames(['pm-button--small', className])} {...rest}>
             {children}
         </Button>
     );

--- a/components/button/WarningButton.js
+++ b/components/button/WarningButton.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../icon/Icon';
 import Button from './Button';
+import { classnames } from '../../helpers/component';
 
 const WarningButton = ({ children, className = '', icon, ...rest }) => {
     const buttonIcon = typeof icon === 'string' ? <Icon name={icon} fill="light" /> : icon;
 
     return (
-        <Button icon={buttonIcon} className={`pm-button--warning ${className}`} {...rest}>
+        <Button icon={buttonIcon} className={classnames(['pm-button--warning', className])} {...rest}>
             {children}
         </Button>
     );

--- a/components/color/ColorSelector.js
+++ b/components/color/ColorSelector.js
@@ -8,12 +8,12 @@ import { classnames } from '../../helpers/component';
 
 const ColorSelector = ({ selected, onChange, className, colors = LABEL_COLORS }) => {
     return (
-        <ul className={classnames('ColorSelector-container unstyled', className)}>
+        <ul className={classnames(['ColorSelector-container unstyled', className])}>
             {colors.map((color, i) => {
                 return (
                     <li
                         key={'mykey' + i}
-                        className={classnames('ColorSelector-item', selected === color && 'selected')}
+                        className={classnames(['ColorSelector-item', selected === color && 'selected'])}
                         style={{ color }}
                     >
                         <Input

--- a/components/color/ColorSelector.js
+++ b/components/color/ColorSelector.js
@@ -4,18 +4,16 @@ import { Icon, Input } from 'react-components';
 import { LABEL_COLORS } from 'proton-shared/lib/constants';
 
 import './ColorSelector.scss';
+import { classnames } from '../../helpers/component';
 
 const ColorSelector = ({ selected, onChange, className, colors = LABEL_COLORS }) => {
-    const getClass = (className, more) => {
-        return [className, more].filter(Boolean).join(' ');
-    };
     return (
-        <ul className={getClass('ColorSelector-container unstyled', className)}>
+        <ul className={classnames('ColorSelector-container unstyled', className)}>
             {colors.map((color, i) => {
                 return (
                     <li
                         key={'mykey' + i}
-                        className={getClass('ColorSelector-item', selected === color && 'selected')}
+                        className={classnames('ColorSelector-item', selected === color && 'selected')}
                         style={{ color }}
                     >
                         <Input

--- a/components/container/Block.js
+++ b/components/container/Block.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Block = ({ children, className = '' }) => {
-    return <div className={`mb1 ${className}`}>{children}</div>;
+    return <div className={classnames(['mb1', className])}>{children}</div>;
 };
 
 Block.propTypes = {

--- a/components/container/Bordered.js
+++ b/components/container/Bordered.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Bordered = ({ children, className = '', ...rest }) => {
     return (
-        <div className={`bordered-container p1 mb1 ${className}`} {...rest}>
+        <div className={classnames(['bordered-container p1 mb1', className])} {...rest}>
             {children}
         </div>
     );

--- a/components/container/Row.js
+++ b/components/container/Row.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Row = ({ children, className = '', ...rest }) => {
     return (
-        <div className={`flex flex-nowrap onmobile-flex-column mb1 ${className}`} {...rest}>
+        <div className={classnames(['flex flex-nowrap onmobile-flex-column mb1', className])} {...rest}>
             {children}
         </div>
     );

--- a/components/dropdown/DropdownActions.js
+++ b/components/dropdown/DropdownActions.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Info, Button, Group, ButtonGroup } from 'react-components';
 import { c } from 'ttag';
+import { classnames } from '../../helpers/component';
 
 import DropdownMenu from './DropdownMenu';
 import DropdownMenuButton from './DropdownMenuButton';
@@ -43,7 +44,7 @@ const DropdownActions = ({ loading = false, disabled = false, list = [], classNa
                 originalPlacement="bottom-right"
                 disabled={disabled}
                 loading={loading}
-                className={`pm-group-button pm-button--for-icon ${className}`}
+                className={classnames(['pm-group-button pm-button--for-icon', className])}
                 title={c('Title').t`Open actions dropdown`}
                 content=""
             >

--- a/components/dropdown/DropdownActions.js
+++ b/components/dropdown/DropdownActions.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Info, Button, Group, ButtonGroup } from 'react-components';
 import { c } from 'ttag';
-import { classnames } from '../../helpers/component';
 
 import DropdownMenu from './DropdownMenu';
 import DropdownMenuButton from './DropdownMenuButton';
 import SimpleDropdown from './SimpleDropdown';
+import { classnames } from '../../helpers/component';
 
 const wrapTooltip = (text, tooltip) => {
     if (!tooltip) {

--- a/components/dropdown/DropdownButton.js
+++ b/components/dropdown/DropdownButton.js
@@ -8,7 +8,7 @@ const DropdownButton = ({ className = '', hasCaret = false, isOpen, children, ..
     return (
         <Button className={classnames(['flex-item-noshrink', className])} aria-expanded={isOpen} {...rest}>
             <span className="mauto">
-                <span className={classnames([hasCaret && children ? 'mr0-5' : ''])}>{children}</span>
+                <span className={classnames([hasCaret && children && 'mr0-5'])}>{children}</span>
                 {hasCaret && <DropdownCaret isOpen={isOpen} />}
             </span>
         </Button>

--- a/components/dropdown/DropdownButton.js
+++ b/components/dropdown/DropdownButton.js
@@ -8,7 +8,7 @@ const DropdownButton = ({ className = '', hasCaret = false, isOpen, children, ..
     return (
         <Button className={classnames(['flex-item-noshrink', className])} aria-expanded={isOpen} {...rest}>
             <span className="mauto">
-                <span className={hasCaret && children ? 'mr0-5' : ''}>{children}</span>
+                <span className={classnames([hasCaret && children ? 'mr0-5' : ''])}>{children}</span>
                 {hasCaret && <DropdownCaret isOpen={isOpen} />}
             </span>
         </Button>

--- a/components/dropdown/DropdownMenu.js
+++ b/components/dropdown/DropdownMenu.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const DropdownMenu = ({ children, className = '' }) => {
     return (
         <div className="dropDown-content">
-            <ul className={`unstyled mt0 mb0 ml1 mr1 ${className}`}>
+            <ul className={classnames(['unstyled mt0 mb0 ml1 mr1', className])}>
                 {React.Children.toArray(children).map((child) => {
                     return (
                         <li className="dropDown-item" key={child.key}>

--- a/components/dropdown/DropdownMenuButton.js
+++ b/components/dropdown/DropdownMenuButton.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const DropdownMenuButton = ({ className = '', disabled, loading, children, ...rest }) => {
     return (
-        <button type="button" disabled={disabled || loading} className={`w100 pt0-5 pb0-5 ${className}`} {...rest}>
+        <button
+            type="button"
+            disabled={disabled || loading}
+            className={classnames(['w100 pt0-5 pb0-5', className])}
+            {...rest}
+        >
             {children}
         </button>
     );

--- a/components/dropdown/DropdownMenuLink.js
+++ b/components/dropdown/DropdownMenuLink.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const DropdownMenuLink = ({ className = '', children, ...rest }) => {
     return (
-        <a className={`w100 pt0-5 pb0-5 inbl nodecoration ${className}`} {...rest}>
+        <a className={classnames(['w100 pt0-5 pb0-5 inbl nodecoration', className])} {...rest}>
             {children}
         </a>
     );

--- a/components/icon/Icon.js
+++ b/components/icon/Icon.js
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 /**
  * Component to print svg icon
@@ -35,7 +36,7 @@ const Icon = ({
             <svg
                 style={style}
                 viewBox={viewBox}
-                className={`icon-${size}p `.concat(fillClass, className).trim()}
+                className={classnames([`icon-${size}p`, fillClass, className])}
                 role="img"
                 focusable="false"
                 {...rest}

--- a/components/icon/RoundedIcon.js
+++ b/components/icon/RoundedIcon.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from './Icon';
+import { classnames } from '../../helpers/component';
 
 const TYPES = {
     success: 'bg-global-success',
@@ -11,7 +12,7 @@ const TYPES = {
 
 const RoundedIcon = ({ className = 'inline-flex rounded50', type = 'success', padding = 'p0-25', ...rest }) => {
     return (
-        <span className={`${className} ${padding} ${TYPES[type]}`}>
+        <span className={classnames([className, padding, TYPES[type]])}>
             <Icon {...rest} />
         </span>
     );

--- a/components/input/DateInput.js
+++ b/components/input/DateInput.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import Pikaday from 'pikaday';
+import { classnames } from '../../helpers/component';
 
 // Configuration: https://github.com/Pikaday/Pikaday#configuration
 const DateInput = ({ id, disabled, required = false, placeholder, className = '', ...rest }) => {
@@ -18,7 +19,7 @@ const DateInput = ({ id, disabled, required = false, placeholder, className = ''
     return (
         <input
             id={id}
-            className={`pm-field w100 ${className}`}
+            className={classnames(['pm-field w100', className])}
             placeholder={placeholder}
             disabled={disabled}
             required={required}

--- a/components/input/FileInput.js
+++ b/components/input/FileInput.js
@@ -1,5 +1,6 @@
 import React, { forwardRef, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const FileInput = forwardRef(({ children, id = 'fileInput', className, onChange, ...rest }, ref) => {
     const newRef = useRef();
@@ -12,7 +13,7 @@ const FileInput = forwardRef(({ children, id = 'fileInput', className, onChange,
     };
 
     return (
-        <label className={'pm-button '.concat(className || '')} htmlFor={id}>
+        <label className={classnames(['pm-button', className])} htmlFor={id}>
             <input id={id} type="file" className="hidden" onChange={handleChange} {...rest} ref={fileRef} />
             {children}
         </label>

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -58,7 +58,7 @@ const Input = React.forwardRef(
                 ) : null}
                 {addIconWrapper(
                     <input
-                        className={`pm-field w100 ${className} ${statusClasses}`}
+                        className={classnames(['pm-field w100', className, statusClasses])}
                         aria-invalid={errorZone && status.isDirty}
                         aria-describedby={uid}
                         id={id}

--- a/components/input/TextArea.js
+++ b/components/input/TextArea.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { generateUID } from '../../helpers/component';
+import { generateUID, classnames } from '../../helpers/component';
 import useAutoGrow from '../../hooks/useAutoGrow';
 import useInput from './useInput';
 import ErrorZone from '../text/ErrorZone';
@@ -26,7 +26,7 @@ const TextArea = (props) => {
         <>
             <textarea
                 rows={rows}
-                className={`pm-field w100 ${className} ${statusClasses}`}
+                className={classnames(['pm-field w100', className, statusClasses])}
                 aria-invalid={error && status.isDirty}
                 aria-describedby={uid}
                 {...rest}

--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Label = ({ htmlFor, className = '', children, ...rest }) => {
     return (
-        <label htmlFor={htmlFor} className={`pm-label ${className}`} {...rest}>
+        <label htmlFor={htmlFor} className={classnames(['pm-label', className])} {...rest}>
             {children}
         </label>
     );

--- a/components/logo/MainLogo.js
+++ b/components/logo/MainLogo.js
@@ -10,6 +10,7 @@ import CalendarLogo from './CalendarLogo';
 import ContactsLogo from './ContactsLogo';
 import MailLogo from './MailLogo';
 import VpnLogo from './VpnLogo';
+import { classnames } from '../../helpers/component';
 
 const { MAIL, VPN } = PLAN_SERVICES;
 const { PROTONMAIL, PROTONCONTACTS, PROTONDRIVE, PROTONCALENDAR, PROTONVPN_SETTINGS, PROTONMAIL_SETTINGS } = APPS;
@@ -22,7 +23,7 @@ const { PROTONMAIL, PROTONCONTACTS, PROTONDRIVE, PROTONCALENDAR, PROTONVPN_SETTI
 const MainLogo = ({ url = '/inbox', external = false, className = '' }) => {
     const { APP_NAME, CLIENT_TYPE } = useConfig();
     const [subscription] = useSubscription();
-    const classNames = `logo-container nodecoration flex flex-item-centered-vert ${className}`;
+    const classNames = classnames([`logo-container nodecoration flex flex-item-centered-vert`, className]);
     const planName = getPlanName(subscription, CLIENT_TYPE === CLIENT_TYPES.VPN ? VPN : MAIL);
 
     const logo = (() => {

--- a/components/logo/MainLogo.js
+++ b/components/logo/MainLogo.js
@@ -23,7 +23,7 @@ const { PROTONMAIL, PROTONCONTACTS, PROTONDRIVE, PROTONCALENDAR, PROTONVPN_SETTI
 const MainLogo = ({ url = '/inbox', external = false, className = '' }) => {
     const { APP_NAME, CLIENT_TYPE } = useConfig();
     const [subscription] = useSubscription();
-    const classNames = classnames([`logo-container nodecoration flex flex-item-centered-vert`, className]);
+    const classNames = classnames(['logo-container nodecoration flex flex-item-centered-vert', className]);
     const planName = getPlanName(subscription, CLIENT_TYPE === CLIENT_TYPES.VPN ? VPN : MAIL);
 
     const logo = (() => {

--- a/components/modal/Content.js
+++ b/components/modal/Content.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'proton-shared/lib/helpers/function';
+import { classnames } from '../../helpers/component';
 
 const Content = ({ children, className = '', onSubmit = noop, onReset = noop, autoComplete = 'off', ...rest }) => {
     const handleSubmit = (event) => {
@@ -12,7 +13,7 @@ const Content = ({ children, className = '', onSubmit = noop, onReset = noop, au
             onSubmit={handleSubmit}
             onReset={onReset}
             autoComplete={autoComplete}
-            className={`pm-modalContent ${className}`}
+            className={classnames(['pm-modalContent', className])}
             {...rest}
         >
             {children}

--- a/components/modal/Footer.js
+++ b/components/modal/Footer.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Footer = ({ children, className = 'flex flex-spacebetween', ...rest }) => {
     return (
-        <footer className={`pm-modalFooter ${className}`} {...rest}>
+        <footer className={classnames(['pm-modalFooter', className])} {...rest}>
             {children}
         </footer>
     );

--- a/components/modal/Header.js
+++ b/components/modal/Header.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
+import { classnames } from '../../helpers/component';
 
 const Header = ({ children, modalTitleID, className = '', hasClose = true, onClose, ...rest }) => {
     return (
-        <header className={`pm-modalHeader ${className}`} {...rest}>
+        <header className={classnames(['pm-modalHeader', className])} {...rest}>
             {hasClose ? (
                 <button type="button" className="pm-modalClose" title={c('Action').t`Close modal`} onClick={onClose}>
                     ×

--- a/components/modal/Inner.js
+++ b/components/modal/Inner.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Inner = ({ children, className = '' }) => (
-    <div className={'pm-modalContentInner '.concat(className)}>{children}</div>
+    <div className={classnames(['pm-modalContentInner', className])}>{children}</div>
 );
 
 Inner.propTypes = {

--- a/components/modal/Overlay.js
+++ b/components/modal/Overlay.js
@@ -15,11 +15,13 @@ const Overlay = ({ isClosing = false, className: extraClassName = '', onExit, ..
         }
     };
 
-    const className = classnames([CLASSES.OVERLAY, isClosing && CLASSES.OVERLAY_OUT, extraClassName]);
-
     return (
         <Portal>
-            <div className={className} onAnimationEnd={handleAnimationEnd} {...rest} />
+            <div
+                className={classnames([CLASSES.OVERLAY, isClosing && CLASSES.OVERLAY_OUT, extraClassName])}
+                onAnimationEnd={handleAnimationEnd}
+                {...rest}
+            />
         </Portal>
     );
 };

--- a/components/modal/Overlay.js
+++ b/components/modal/Overlay.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from '../portal/Portal';
+import { classnames } from '../../helpers/component';
 
 const CLASSES = {
     OVERLAY: 'pm-modalOverlay',
@@ -14,7 +15,7 @@ const Overlay = ({ isClosing = false, className: extraClassName = '', onExit, ..
         }
     };
 
-    const className = [CLASSES.OVERLAY, isClosing && CLASSES.OVERLAY_OUT, extraClassName].filter(Boolean).join(' ');
+    const className = classnames([CLASSES.OVERLAY, isClosing && CLASSES.OVERLAY_OUT, extraClassName]);
 
     return (
         <Portal>

--- a/components/orderableTable/OrderableTable.js
+++ b/components/orderableTable/OrderableTable.js
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types';
 import { Table } from '../table';
 import OrderableContainer from '../orderable/OrderableContainer';
 import './OrderableTable.scss';
+import { classnames } from '../../helpers/component';
 
 const OrderableTable = ({ children = [], className = '', caption, ...props }) => (
     <OrderableContainer helperClass="orderableHelper pm-simple-table" useDragHandle {...props}>
-        <Table caption={caption} className={`orderableTable ${className}`}>
+        <Table caption={caption} className={classnames(['orderableTable', className])}>
             {children}
         </Table>
     </OrderableContainer>

--- a/components/orderableTable/OrderableTableHeader.js
+++ b/components/orderableTable/OrderableTableHeader.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { TableHeader } from '../table';
 import './OrderableTableHeader.scss';
+import { classnames } from '../../helpers/component';
 
 const OrderableTableHeader = ({ cells = [], className = '', children, ...rest }) => (
     <TableHeader
@@ -10,7 +11,7 @@ const OrderableTableHeader = ({ cells = [], className = '', children, ...rest })
             null, // column for icon
             ...cells
         ]}
-        className={`orderableTableHeader ${className}`}
+        className={classnames(['orderableTableHeader', className])}
         {...rest}
     >
         {children}

--- a/components/paragraph/Paragraph.js
+++ b/components/paragraph/Paragraph.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Paragraph = ({ className = '', children }) => {
-    return <div className={`pt1 pb1 ${className}`}>{children}</div>;
+    return <div className={classnames(['pt1 pb1', className])}>{children}</div>;
 };
 
 Paragraph.propTypes = {

--- a/components/price/Price.js
+++ b/components/price/Price.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const CURRENCIES = {
     USD: '$',
@@ -16,7 +17,7 @@ const Price = ({ children: amount = 0, currency = '', className = '', divisor = 
 
     if (currency === 'USD') {
         return (
-            <span className={`price ${className}`} data-currency={currency}>
+            <span className={classnames(['price', className])} data-currency={currency}>
                 {p}
                 {c}
                 {v}
@@ -26,7 +27,7 @@ const Price = ({ children: amount = 0, currency = '', className = '', divisor = 
     }
 
     return (
-        <span className={`price ${className}`} data-currency={currency}>
+        <span className={classnames(['price', className])} data-currency={currency}>
             {p}
             {v}
             {currency ? <> {c}</> : null}

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { generateUID } from '../../helpers/component';
+import { generateUID, classnames } from '../../helpers/component';
 import useInput from '../input/useInput';
 import ErrorZone from '../text/ErrorZone';
 
@@ -12,7 +12,7 @@ const Select = ({ options, error, size = 1, className = '', multiple = false, lo
     return (
         <>
             <select
-                className={`pm-field w100 ${className} ${statusClasses}`}
+                className={classnames(['pm-field w100', className, statusClasses])}
                 size={size}
                 multiple={multiple}
                 disabled={loading || rest.disabled}

--- a/components/sidebar/NavItem.js
+++ b/components/sidebar/NavItem.js
@@ -4,6 +4,7 @@ import { NavLink } from 'react-router-dom';
 
 import Icon from '../icon/Icon';
 import NavMenu from './NavMenu';
+import { classnames } from '../../helpers/component';
 
 const NavItem = ({ type = 'link', link, isActive, text, aside, onClick, icon, list = [], color, className = '' }) => {
     const content = (
@@ -23,7 +24,7 @@ const NavItem = ({ type = 'link', link, isActive, text, aside, onClick, icon, li
     if (type === 'link') {
         return (
             <li className="navigation__item">
-                <NavLink className={`navigation__link ${className}`} isActive={isActive} to={link}>
+                <NavLink className={classnames(['navigation__ling', className])} isActive={isActive} to={link}>
                     {content}
                 </NavLink>
                 {list.length ? <NavMenu list={list} /> : null}
@@ -34,7 +35,7 @@ const NavItem = ({ type = 'link', link, isActive, text, aside, onClick, icon, li
     if (type === 'text') {
         return (
             <li className="navigation__item">
-                <span className={`navigation__link ${className}`}>
+                <span className={classnames(['navigation__link', className])}>
                     {content}
                     {list.length ? <NavMenu list={list} /> : null}
                 </span>
@@ -45,7 +46,7 @@ const NavItem = ({ type = 'link', link, isActive, text, aside, onClick, icon, li
     if (type === 'button') {
         return (
             <li className="navigation__item">
-                <button type="button" className={`w100 navigation__link ${className}`} onClick={onClick}>
+                <button type="button" className={classnames(['w100 navigation__link', className])} onClick={onClick}>
                     {content}
                 </button>
                 {list.length ? <NavMenu list={list} /> : null}

--- a/components/sidebar/NavItem.js
+++ b/components/sidebar/NavItem.js
@@ -24,7 +24,7 @@ const NavItem = ({ type = 'link', link, isActive, text, aside, onClick, icon, li
     if (type === 'link') {
         return (
             <li className="navigation__item">
-                <NavLink className={classnames(['navigation__ling', className])} isActive={isActive} to={link}>
+                <NavLink className={classnames(['navigation__link', className])} isActive={isActive} to={link}>
                     {content}
                 </NavLink>
                 {list.length ? <NavMenu list={list} /> : null}

--- a/components/table/Table.js
+++ b/components/table/Table.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Table = ({ children = [], className = '', caption }) => {
     return (
-        <table className={`pm-simple-table ${className}`}>
+        <table className={classnames(['pm-simple-table', className])}>
             {caption ? <caption className="sr-only">{caption}</caption> : null}
             {children}
         </table>

--- a/components/text/Preformatted.js
+++ b/components/text/Preformatted.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Preformatted = ({ className = '', ...rest }) => {
-    return <pre className={`bg-global-muted p1 mb1 scroll-if-needed ${className}`} {...rest} />;
+    return <pre className={classnames(['bg-global-muted p1 mb1 scroll-if-needed', className])} {...rest} />;
 };
 
 Preformatted.propTypes = {

--- a/components/toggle/Toggle.js
+++ b/components/toggle/Toggle.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { c } from 'ttag';
 
 import Icon from '../icon/Icon';
+import { classnames } from '../../helpers/component';
 
 const label = (key) => {
     const I18N = {
@@ -39,7 +40,7 @@ const Toggle = ({ id = 'toggle', className = '', checked = false, loading, onCha
                 aria-busy={loading}
                 {...rest}
             />
-            <label htmlFor={id} className={`pm-toggle-label ${className}`}>
+            <label htmlFor={id} className={classnames(['pm-toggle-label', className])}>
                 {label('off')}
                 {label('on')}
             </label>

--- a/components/wizard/Wizard.js
+++ b/components/wizard/Wizard.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const Wizard = ({ step = 0, steps = [], hideText = false }) => {
     return (
-        <div className={`wizard-container ${hideText ? 'wizard-container--noTextDisplayed' : ''}`}>
+        <div className={classnames(['wizard-container', hideText ? 'wizard-container--noTextDisplayed' : ''])}>
             <ul className="wizard unstyled flex flex-nowrap flex-spacebetween">
                 {steps.map((text = '', index) => {
                     return (
                         <li
                             key={index.toString()}
-                            className={`wizard-item ${index < step ? 'is-complete' : ''}`}
+                            className={classnames(['wizard-item', index < step ? 'is-complete' : ''])}
                             aria-current={index === step ? 'step' : null}
                         >
                             <span className="wizard-marker" />

--- a/components/wizard/Wizard.js
+++ b/components/wizard/Wizard.js
@@ -4,13 +4,13 @@ import { classnames } from '../../helpers/component';
 
 const Wizard = ({ step = 0, steps = [], hideText = false }) => {
     return (
-        <div className={classnames(['wizard-container', hideText ? 'wizard-container--noTextDisplayed' : ''])}>
+        <div className={classnames(['wizard-container', hideText && 'wizard-container--noTextDisplayed'])}>
             <ul className="wizard unstyled flex flex-nowrap flex-spacebetween">
                 {steps.map((text = '', index) => {
                     return (
                         <li
                             key={index.toString()}
-                            className={classnames(['wizard-item', index < step ? 'is-complete' : ''])}
+                            className={classnames(['wizard-item', index < step && 'is-complete'])}
                             aria-current={index === step ? 'step' : null}
                         >
                             <span className="wizard-marker" />

--- a/containers/autoReply/InfoLine.tsx
+++ b/containers/autoReply/InfoLine.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { classnames } from '../../helpers/component';
 
 interface Props {
     plain: boolean;

--- a/containers/autoReply/InfoLine.tsx
+++ b/containers/autoReply/InfoLine.tsx
@@ -9,7 +9,7 @@ interface Props {
 const InfoLine = ({ label, children, plain = false }: Props) => (
     <tr className="mb1 w100 aligntop">
         <td className="pr1">{label}</td>
-        <td className={`w100 ${plain ? '' : 'bold'}`}>{children}</td>
+        <td className={classnames(['w100', !plain && 'bold'])}>{children}</td>
     </tr>
 );
 

--- a/containers/cache/CacheContext.js
+++ b/containers/cache/CacheContext.js
@@ -1,3 +1,0 @@
-import { createContext } from 'react';
-
-export default createContext();

--- a/containers/cache/cacheContext.js
+++ b/containers/cache/cacheContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext();

--- a/containers/cache/cacheContext.js
+++ b/containers/cache/cacheContext.js
@@ -1,3 +1,0 @@
-import { createContext } from 'react';
-
-export default createContext();

--- a/containers/filters/editor/Preview.js
+++ b/containers/filters/editor/Preview.js
@@ -5,6 +5,7 @@ import { Alert, Row, Label, useFormattedLabels } from 'react-components';
 
 import PreviewActionValue from './PreviewActionValue';
 import './Preview.css';
+import { classnames } from '../../../helpers/component';
 
 const formatActions = (actions, labelsModel) => {
     const getMarkLabel = ({ Starred, Read }) => {
@@ -85,7 +86,7 @@ function PreviewFilter({ filter }) {
             <div className="Preview-row">
                 <b className="mb1">{c('Filter preview').t`Conditions`}:</b>
                 {Conditions.map(({ Comparator, Type, Values }, i) => {
-                    const className = 'Preview-condition'.concat(!i ? ' mt1' : '');
+                    const className = classnames(['Preview-condition', !i && 'mt1']);
 
                     return (
                         <Row className={className} key={i.toString()}>
@@ -120,7 +121,7 @@ function PreviewFilter({ filter }) {
                 <b>{c('Filter preview').t`Actions`}:</b>
 
                 {formatActions(Actions, labelsModel).map(({ label, value, icon }, i) => {
-                    const className = 'Preview-condition'.concat(!i ? ' mt1' : '');
+                    const className = classnames(['Preview-condition', !i && 'mt1']);
                     return (
                         <Row className={className} key={i.toString()}>
                             {!i ? (

--- a/containers/filters/spamlist/SpamListItem.js
+++ b/containers/filters/spamlist/SpamListItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { SubTitle, Bordered, Loader, Alert, Group } from 'react-components';
 import { noop } from 'proton-shared/lib/helpers/function';
+import { classnames } from '../../../helpers/component';
 
 import AddEmailFilterListButton from './AddEmailFilterListButton';
 import MoveEmailFilteredList from './MoveEmailFilteredList';
@@ -21,7 +22,7 @@ function SpamListItem({ list, type, dest, onAction = noop, className, loading })
     };
 
     return (
-        <Bordered className={'flex-autogrid-item '.concat(className)}>
+        <Bordered className={classnames(['flex-autogrid-item', className])}>
             <header className="mt1 flex flex-spacebetween">
                 <SubTitle>{I18N[type]}</SubTitle>
                 <div>

--- a/containers/illustration/IllustrationPlaceholder.js
+++ b/containers/illustration/IllustrationPlaceholder.js
@@ -8,7 +8,7 @@ const IllustrationPlaceholder = ({ className, title, text, url, uppercase, child
     return (
         <div className={classnames(['flex flex-column flex-items-center w100', className])}>
             <img src={url} alt={title} className="p1 mb1" />
-            <h2 className={classnames(['bold', uppercase ? 'uppercase' : ''])}>{title}</h2>
+            <h2 className={classnames(['bold', uppercase && 'uppercase'])}>{title}</h2>
             {info}
             {children}
         </div>

--- a/containers/illustration/IllustrationPlaceholder.js
+++ b/containers/illustration/IllustrationPlaceholder.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { classnames } from '../../helpers/component';
 
 const IllustrationPlaceholder = ({ className, title, text, url, uppercase, children }) => {
     const info = typeof text === 'string' ? <p>{text}</p> : text;
 
     return (
-        <div className={`flex flex-column flex-items-center w100 ${className}`}>
+        <div className={classnames(['flex flex-column flex-items-center w100', className])}>
             <img src={url} alt={title} className="p1 mb1" />
-            <h2 className={`bold ${uppercase ? 'uppercase' : ''}`}>{title}</h2>
+            <h2 className={classnames(['bold', uppercase ? 'uppercase' : ''])}>{title}</h2>
             {info}
             {children}
         </div>

--- a/containers/overview/IndexSection.js
+++ b/containers/overview/IndexSection.js
@@ -13,7 +13,7 @@ const IndexSection = ({ pages }) => {
                 return (
                     <div
                         key={route}
-                        className={classnames(['setting-grid', sections.length > 4 ? 'setting-grid--tall' : ''])}
+                        className={classnames(['setting-grid', sections.length > 4 && 'setting-grid--tall'])}
                     >
                         <h2 className="h6 mb0-5">
                             <strong>{text}</strong>

--- a/containers/overview/IndexSection.js
+++ b/containers/overview/IndexSection.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { usePermissions } from 'react-components';
+import { classnames } from '../../helpers/component';
 
 import Sections from './Sections';
 
@@ -10,7 +11,10 @@ const IndexSection = ({ pages }) => {
         <div className="settings-grid-container">
             {pages.map(({ text, route, sections = [], permissions: pagePermissions }) => {
                 return (
-                    <div key={route} className={`setting-grid ${sections.length > 4 ? 'setting-grid--tall' : ''}`}>
+                    <div
+                        key={route}
+                        className={classnames(['setting-grid', sections.length > 4 ? 'setting-grid--tall' : ''])}
+                    >
                         <h2 className="h6 mb0-5">
                             <strong>{text}</strong>
                         </h2>

--- a/containers/payments/AmountButton.js
+++ b/containers/payments/AmountButton.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Price } from 'react-components';
+import { classnames } from '../../helpers/component';
 
 const AmountButton = ({ value = 0, amount = 0, currency, onSelect, className = '' }) => {
     return (
-        <Button className={`${className} ${value === amount ? 'is-active' : ''}`} onClick={() => onSelect(value)}>
+        <Button
+            className={classnames([className, value === amount ? 'is-active' : ''])}
+            onClick={() => onSelect(value)}
+        >
             <Price currency={currency}>{value}</Price>
         </Button>
     );

--- a/containers/payments/AmountButton.js
+++ b/containers/payments/AmountButton.js
@@ -5,10 +5,7 @@ import { classnames } from '../../helpers/component';
 
 const AmountButton = ({ value = 0, amount = 0, currency, onSelect, className = '' }) => {
     return (
-        <Button
-            className={classnames([className, value === amount ? 'is-active' : ''])}
-            onClick={() => onSelect(value)}
-        >
+        <Button className={classnames([className, value === amount && 'is-active'])} onClick={() => onSelect(value)}>
             <Price currency={currency}>{value}</Price>
         </Button>
     );

--- a/containers/sidebar/StorageSpaceStatus.js
+++ b/containers/sidebar/StorageSpaceStatus.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { CircularProgress, Dropdown, Icon, generateUID, useUser, usePopperAnchor } from 'react-components';
 import humanSize from 'proton-shared/lib/helpers/humanSize';
+import { classnames } from '../../helpers/component';
 
 const StorageSpaceStatus = ({ children }) => {
     const [{ MaxSpace, UsedSpace }] = useUser();
@@ -59,7 +60,7 @@ const StorageSpaceStatus = ({ children }) => {
                                 <CircularProgress
                                     progress={usedPercent}
                                     size={100}
-                                    className={`circle-chart__background--bigger ${color}`}
+                                    className={classnames(['circle-chart__background--bigger', color])}
                                 />
                                 <span className="centered-absolute">{usedPercent}%</span>
                             </div>


### PR DESCRIPTION
Issue : https://github.com/ProtonMail/react-components/issues/274

The issue asked to remove all the interpolations for `className` attribute and use the helper function located in `helpers/component.js`.

After updating all the attributes, I have ran the following steps:
- ran all the tests to be sure I didn't break anything
- linting with pre-commit hook