### PR TITLE
Add validation error when user misstypes DANGER

### DIFF
--- a/containers/resetPassword/DangerVerificationForm.js
+++ b/containers/resetPassword/DangerVerificationForm.js
@@ -16,6 +16,10 @@ const DangerVerificationForm = ({ onSubmit }) => {
         <form
             onSubmit={(e) => {
                 e.preventDefault();
+
+                if (value !== WORD) {
+                    return;
+                }
                 onSubmit();
             }}
         >
@@ -31,6 +35,7 @@ const DangerVerificationForm = ({ onSubmit }) => {
                     value={value}
                     pattern={WORD}
                     onChange={({ target }) => updateValue(target.value)}
+                    error={value.length > 0 && value !== WORD ? c('Error').t`Please enter '${WORD}'` : ''}
                     required
                 />
             </div>


### PR DESCRIPTION
Fixes https://github.com/ProtonMail/proton-vpn-settings/issues/294

Note:
I couldn't test it, as google captcha verification fails at server side every time I pass it on localhost.
