### PR TITLE
Round to 0.01 precision in the storage selector

### DIFF
--- a/containers/sidebar/StorageSpaceStatus.js
+++ b/containers/sidebar/StorageSpaceStatus.js
@@ -10,7 +10,8 @@ const StorageSpaceStatus = ({ children }) => {
     const [uid] = useState(generateUID('dropdown'));
     const { anchorRef, isOpen, toggle, close } = usePopperAnchor();
 
-    const usedPercent = Math.round(UsedSpace / MaxSpace);
+    // round with 0.01 precision
+    const usedPercent = Math.round((UsedSpace / MaxSpace) * 10000) / 100;
     const maxSpaceFormatted = humanSize(MaxSpace);
     const usedSpaceFormatted = humanSize(UsedSpace);
     const color =


### PR DESCRIPTION
Right now the rounding in the storage selector does not give a percentage, but rather 0 or 1. I'm rounding to 0.01 precision here (so that percentages displayed are things like 32.44%, 0.12%, etc). But if we want to round just to an integer, simply do
```
Math.round((UsedSpace / MaxSpace) * 100)
```

Fixes https://github.com/ProtonMail/proton-contacts/issues/174