### PR TITLE
Add proptypes to confirm modal

### DIFF
--- a/components/modal/Confirm.js
+++ b/components/modal/Confirm.js
@@ -35,8 +35,8 @@ Confirm.propTypes = {
     onConfirm: PropTypes.func,
     title: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
-    cancel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    confirm: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    cancel: PropTypes.node,
+    confirm: PropTypes.node,
     loading: PropTypes.bool
 };
 

--- a/components/modal/Confirm.js
+++ b/components/modal/Confirm.js
@@ -35,8 +35,8 @@ Confirm.propTypes = {
     onConfirm: PropTypes.func,
     title: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
-    cancel: PropTypes.string,
-    confirm: PropTypes.string,
+    cancel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    confirm: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     loading: PropTypes.bool
 };
 


### PR DESCRIPTION
`confirm` and `cancel` should have the same propTypes as `submit` and `cancel` in `FormModal`