### PR TITLE
added dropzone component

### DIFF
--- a/components/dropzone/dropzone.jsx
+++ b/components/dropzone/dropzone.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './dropzone.sass';
+
+const CLASSNAMES = {
+  default: 'dropBorder-default',
+  error: 'dropBorder-error',
+  success: 'dropBorder-success'
+};
+
+class DropZone extends React.Component {
+  state = {
+    status: 'default'
+  };
+
+  handleDrag = e => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  handleDragIn = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.dataTransfer.items) {
+      if (
+        e.dataTransfer.items.length === 1 &&
+        this.props.validTypes.includes(e.dataTransfer.items[0].type)
+      ) {
+        this.setState({ status: 'success' });
+      } else {
+        this.setState({ status: 'error' });
+      }
+    }
+  };
+
+  handleDragOut = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({ status: 'default' });
+  };
+
+  handleDrop = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({ status: 'default' });
+    if (e.dataTransfer.files && e.dataTransfer.files.length === 1) {
+      this.props.handleDrop(e.dataTransfer.files[0]);
+    }
+  };
+
+  render() {
+    return (
+      <div
+        className={`dropBorder ${CLASSNAMES[this.state.status]}`}
+        onDrag={this.handleDrag}
+        onDrop={this.handleDrop}
+        onDragOver={this.handleDragIn}
+        onDragLeave={this.handleDragOut}
+      >
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+DropZone.propTypes = {
+  children: PropTypes.node.isRequired,
+  handleDrop: PropTypes.func,
+  validTypes: PropTypes.array
+};
+
+export default DropZone;

--- a/components/dropzone/dropzone.sass
+++ b/components/dropzone/dropzone.sass
@@ -1,0 +1,21 @@
+.dropBorder 
+    height: 100% 
+    width: 100% 
+    padding: 3rem 
+    border-radius: 30px 
+    text-align: center 
+    flex-direction: column 
+    justify-content: center 
+    
+.dropBorder-default 
+    border: 1px solid #d9d9d9 
+    transition: border-color .3s 
+    
+.dropBorder-default:hover 
+    border-color: #40a9ff 
+        
+.dropBorder-success 
+    border: 1px solid #40a9ff 
+            
+.dropBorder-error 
+    border: 1px solid #f5222d


### PR DESCRIPTION
#139 

I have tried to make a basic dropzone. If I could access the Zeplin mock-up, I could see to change it a bit. When dropping a valid file, the `handleDrop` callback function is called with the file. 

All the children are rendered in a centered column.

Please let me know of any issues and improvements.

## Example

```html
    <DropZone
      handleDrop={file => {
        console.log(file);
      }}
      validTypes={[
        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
        'text/x-vcard'
      ]}
    >
      <h1>DropZone</h1>
      <h1>Drop your file here</h1>
      <input type="file" />
    </DropZone>
```
