### PR TITLE
Shared signup

### DIFF
--- a/components/link/Info.js
+++ b/components/link/Info.js
@@ -6,6 +6,7 @@ import Icon from '../icon/Icon';
 import { usePopper, Popper, usePopperAnchor } from '../popper';
 import useRightToLeft from '../../containers/rightToLeft/useRightToLeft';
 
+/** @type any */
 const Info = ({
     url,
     title,

--- a/containers/signup/AccountStep/AccountForm.js
+++ b/containers/signup/AccountStep/AccountForm.js
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+    Input,
+    PasswordInput,
+    PrimaryButton,
+    Field,
+    useApi,
+    Row,
+    Label,
+    EmailInput,
+    Href,
+    useLoading,
+    Info
+} from 'react-components';
+import { c } from 'ttag';
+import { queryCheckUsernameAvailability } from 'proton-shared/lib/api/user';
+
+const AccountForm = ({ model, onSubmit }) => {
+    const api = useApi();
+    const [username, setUsername] = useState(model.username);
+    const [password, setPassword] = useState(model.password);
+    const [confirmPassword, setConfirmPassword] = useState(model.password);
+    const [email, setEmail] = useState(model.email);
+    const [usernameError, setUsernameError] = useState();
+    const [loading, withLoading] = useLoading();
+
+    const handleChangeUsername = ({ target }) => {
+        if (usernameError) {
+            setUsernameError(null);
+        }
+        setUsername(target.value);
+    };
+
+    const handleChangePassword = ({ target }) => setPassword(target.value);
+    const handleChangeConfirmPassword = ({ target }) => setConfirmPassword(target.value);
+    const handleChangeEmail = ({ target }) => setEmail(target.value);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        if (password !== confirmPassword) {
+            return;
+        }
+
+        try {
+            await api(queryCheckUsernameAvailability(username));
+            await onSubmit({
+                username,
+                password,
+                email
+            });
+        } catch (e) {
+            setUsernameError(e.data ? e.data.Error : c('Error').t`Can't check username, try again later`);
+        }
+    };
+
+    const termsOfServiceLink = (
+        <Href key="terms" url="https://protonvpn.com/terms-and-conditions">{c('Link').t`Terms of Service`}</Href>
+    );
+
+    const privacyPolicyLink = (
+        <Href key="privacy" url="https://protonvpn.com/privacy-policy">{c('Link').t`Privacy Policy`}</Href>
+    );
+
+    return (
+        <form className="flex-item-fluid-auto" onSubmit={(e) => withLoading(handleSubmit(e))}>
+            <Row>
+                <Label htmlFor="username">
+                    <span className="mr0-5">{c('Label').t`Username`}</span>
+                    <Info
+                        title={c('Tooltip')
+                            .t`Username which is used for all Proton services. This can also be used later to create a secure ProtonMail account.`}
+                    />
+                </Label>
+                <Field className="auto flex-item-fluid">
+                    <Input
+                        required
+                        error={usernameError}
+                        value={username}
+                        onChange={handleChangeUsername}
+                        name="username"
+                        id="username"
+                        autoFocus={true}
+                        placeholder={c('Placeholder').t`Username`}
+                    />
+                </Field>
+            </Row>
+
+            <Row>
+                <Label htmlFor="password">
+                    <span className="mr0-5">{c('Label').t`Password`}</span>
+                    <Info
+                        title={c('Tooltip')
+                            .t`If you forget your password, you will no longer have access to your account or your data. Please save it someplace safe.`}
+                    />
+                </Label>
+                <Field className="auto flex-item-fluid">
+                    <div className="mb1">
+                        <PasswordInput
+                            id="password"
+                            required
+                            value={password}
+                            onChange={handleChangePassword}
+                            name="password"
+                            placeholder={c('Placeholder').t`Password`}
+                        />
+                    </div>
+                    <PasswordInput
+                        id="passwordConfirmation"
+                        required
+                        value={confirmPassword}
+                        onChange={handleChangeConfirmPassword}
+                        error={password !== confirmPassword ? c('Error').t`Passwords do not match` : undefined}
+                        name="passwordConfirmation"
+                        placeholder={c('Placeholder').t`Confirm password`}
+                    />
+                </Field>
+            </Row>
+
+            <Row>
+                <Label htmlFor="email">
+                    <span className="mr0-5">{c('Label').t`Email address`}</span>
+                    <Info
+                        title={c('Tooltip')
+                            .t`Your email is not shared with third parties and is only used for recovery and account-related questions or communication.`}
+                    />
+                </Label>
+                <Field className="auto flex-item-fluid">
+                    <div className="mb1">
+                        <EmailInput
+                            id="email"
+                            required
+                            value={email}
+                            onChange={handleChangeEmail}
+                            placeholder={c('Placeholder').t`user@domain.com`}
+                        />
+                    </div>
+                    <p>
+                        {c('Info')
+                            .jt`By clicking Create account you agree to abide by our ${termsOfServiceLink} and ${privacyPolicyLink}.`}
+                    </p>
+
+                    <PrimaryButton loading={loading} type="submit">{c('Action').t`Create account`}</PrimaryButton>
+                </Field>
+            </Row>
+        </form>
+    );
+};
+
+AccountForm.propTypes = {
+    model: PropTypes.object.isRequired,
+    onSubmit: PropTypes.func.isRequired
+};
+
+export default AccountForm;

--- a/containers/signup/AccountStep/AccountStep.js
+++ b/containers/signup/AccountStep/AccountStep.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import AccountForm from './AccountForm';
+import { Row, SubTitle, useModals } from 'react-components';
+import { c } from 'ttag';
+import { hasProtonDomain } from 'proton-shared/lib/helpers/string';
+
+import LoginPromptModal from './LoginPromptModal';
+import LoginPanel from '../LoginPanel';
+
+const AccountStep = ({ onContinue, model, children }) => {
+    const { createModal } = useModals();
+
+    const handleSubmit = ({ email, username, password }) => {
+        if (hasProtonDomain(email)) {
+            createModal(<LoginPromptModal email={email} />);
+        } else {
+            onContinue({ ...model, email, username, password });
+        }
+    };
+
+    return (
+        <div className="pt2 mb2">
+            <SubTitle>{c('Title').t`Create an account`}</SubTitle>
+            <Row>
+                <div>
+                    <AccountForm model={model} onSubmit={handleSubmit} />
+                    <LoginPanel />
+                </div>
+                {children}
+            </Row>
+        </div>
+    );
+};
+
+AccountStep.propTypes = {
+    model: PropTypes.object.isRequired,
+    onContinue: PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired
+};
+
+export default AccountStep;

--- a/containers/signup/AccountStep/LoginPromptModal.js
+++ b/containers/signup/AccountStep/LoginPromptModal.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormModal, PrimaryButton, Alert } from 'react-components';
+import { c } from 'ttag';
+import { Link } from 'react-router-dom';
+
+// TODO: make it more generic (title, login url)
+const LoginPromptModal = ({ email, ...rest }) => {
+    return (
+        <FormModal
+            title={c('Title').t`ProtonVPN`}
+            close={c('Action').t`Cancel`}
+            submit={
+                <Link to="/login">
+                    <PrimaryButton>{c('Action').t`Go to login`}</PrimaryButton>
+                </Link>
+            }
+            {...rest}
+        >
+            <Alert>
+                {c('Info').t`You already have a Proton account.`}
+                <br />
+                {c('Info')
+                    .t`Your existing Proton account can be used to access all Proton services. Please login with ${email}`}
+            </Alert>
+        </FormModal>
+    );
+};
+
+LoginPromptModal.propTypes = {
+    email: PropTypes.string.isRequired
+};
+
+export default LoginPromptModal;

--- a/containers/signup/LoginPanel.js
+++ b/containers/signup/LoginPanel.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { c } from 'ttag';
+import { Link } from 'react-router-dom';
+
+const LoginPanel = () => {
+    return (
+        <div className="border-top mt2 pt2">
+            <h3 className="mb1">{c('Title').t`Already have a Proton account?`}</h3>
+            <div className="mb1-5">{c('Info')
+                .t`If you are a ProtonMail user you can use your Proton account to log in to ProtonVPN.`}</div>
+            <div>
+                <Link className="pm-button--primaryborder" to="/login">{c('Link').t`Log in`}</Link>
+            </div>
+        </div>
+    );
+};
+
+export default LoginPanel;

--- a/containers/signup/MobileRedirectionStep/MobileRedirectionStep.js
+++ b/containers/signup/MobileRedirectionStep/MobileRedirectionStep.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { SubTitle, Href, Icon, Paragraph } from 'react-components';
+
+const MobileRedirectionStep = ({ model }) => {
+    return (
+        <div className="pt2 mb2 aligncenter">
+            <SubTitle>{c('Title').t`Account created`}</SubTitle>
+            <Icon name="on" className="mb2" fill="success" size={100} />
+            <Paragraph className="mb2">{c('Info')
+                .t`Your account has been successfully created. Please press the "Close" button to be taken back to the app.`}</Paragraph>
+            <Href
+                className="pm-button pm-button--primary pm-button--large bold"
+                url={`protonvpn://registered?username=${model.username}`}
+                target="_top"
+            >{c('Link').t`Close`}</Href>
+        </div>
+    );
+};
+
+MobileRedirectionStep.propTypes = {
+    model: PropTypes.object.isRequired
+};
+
+export default MobileRedirectionStep;

--- a/containers/signup/PaymentStep/PaymentStep.js
+++ b/containers/signup/PaymentStep/PaymentStep.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Payment, usePayment, PrimaryButton, Field, Row, useLoading, SubTitle } from 'react-components';
+import { c } from 'ttag';
+import { PAYMENT_METHOD_TYPES, CYCLE, CURRENCIES } from 'proton-shared/lib/constants';
+
+import LoginPanel from '../LoginPanel';
+
+const PaymentStep = ({ onPay, paymentAmount, model, children }) => {
+    const [loading, withLoading] = useLoading();
+    const { method, setMethod, parameters, canPay, setParameters, setCardValidity } = usePayment();
+
+    return (
+        <div className="pt2 mb2">
+            <SubTitle>{c('Title').t`Provide payment details`}</SubTitle>
+            <Row>
+                <div>
+                    <Alert>{c('Info').t`Your payment details are protected with TLS encryption and Swiss laws`}</Alert>
+                    <Payment
+                        type="signup"
+                        method={method}
+                        amount={paymentAmount}
+                        cycle={model.cycle}
+                        currency={model.currency}
+                        parameters={parameters}
+                        onParameters={setParameters}
+                        onMethod={setMethod}
+                        onValidCard={setCardValidity}
+                        onPay={(params) => withLoading(onPay(model, params))}
+                        fieldClassName="auto flex-item-fluid-auto"
+                    >
+                        {method === PAYMENT_METHOD_TYPES.CARD && (
+                            <Field>
+                                <PrimaryButton
+                                    loading={loading}
+                                    disabled={!canPay}
+                                    onClick={() => withLoading(onPay(model, parameters))}
+                                >{c('Action').t`Confirm payment`}</PrimaryButton>
+                            </Field>
+                        )}
+                    </Payment>
+                    <LoginPanel />
+                </div>
+                {children}
+            </Row>
+        </div>
+    );
+};
+
+PaymentStep.propTypes = {
+    paymentAmount: PropTypes.number.isRequired,
+    model: PropTypes.shape({
+        cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.TWO_YEARS, CYCLE.YEARLY]).isRequired,
+        currency: PropTypes.oneOf(CURRENCIES).isRequired
+    }),
+    onPay: PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired
+};
+
+export default PaymentStep;

--- a/containers/signup/PlanStep/OSIcon.js
+++ b/containers/signup/PlanStep/OSIcon.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import windowsSvg from 'design-system/assets/img/pm-images/windows.svg';
+import iosSvg from 'design-system/assets/img/pm-images/iOS.svg';
+import linuxSvg from 'design-system/assets/img/pm-images/linux.svg';
+import androidSvg from 'design-system/assets/img/pm-images/android.svg';
+import macosSvg from 'design-system/assets/img/pm-images/macOS.svg';
+
+const OSIcon = ({ os }) => {
+    const src = {
+        windows: windowsSvg,
+        ios: iosSvg,
+        linux: linuxSvg,
+        android: androidSvg,
+        macos: macosSvg
+    };
+    return <img src={src[os]} width={20} className="ml0-25" />;
+};
+
+OSIcon.propTypes = {
+    os: PropTypes.string
+};
+
+export default OSIcon;

--- a/containers/signup/PlanStep/PlanCard/PlanCard.js
+++ b/containers/signup/PlanStep/PlanCard/PlanCard.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classnames, Button, Tooltip, Badge } from 'react-components';
+import { c } from 'ttag';
+import PlanPrice from './PlanPrice';
+import { CYCLE, CURRENCIES } from 'proton-shared/lib/constants';
+
+const PlanCard = ({ plan, isActive, onSelect, cycle, currency, isDisabled }) => {
+    const button = (
+        <Button
+            disabled={isDisabled}
+            onClick={onSelect}
+            className={classnames([
+                'w100 mtauto',
+                !isActive && 'pm-button--primaryborder',
+                isActive && 'pm-button--primary'
+            ])}
+        >
+            {c('Plan Action').t`Get ${plan.title}`}
+        </Button>
+    );
+
+    return (
+        <div
+            className={classnames([
+                'plan-card flex-item-fluid flex flex-column relative',
+                isActive ? 'plan-card--active' : 'nomobile'
+            ])}
+        >
+            <div className="mb1 plan-card-image flex flex-items-end nomobile">{plan.image}</div>
+            <div className="flex flex-items-center relative">
+                <strong className="biggest mt0 mb0">{plan.title}</strong>
+                {plan.isBest && (
+                    <div className="mlauto plan-card-mostPopular">
+                        <Badge>{c('Plan info').t`Most popular`}</Badge>
+                    </div>
+                )}
+            </div>
+            <div className="flex-item-fluid-auto pt1 pb1 flex flex-column">
+                <PlanPrice plan={plan} cycle={cycle} currency={currency} />
+                {plan.description && (
+                    <strong className={classnames(['border-top mt1 pt1 mb1 big', isActive && 'color-primary'])}>
+                        {plan.description}
+                    </strong>
+                )}
+                {plan.additionalFeatures && (
+                    <>
+                        <div>{plan.additionalFeatures}</div>
+                        <strong className="color-primary">+</strong>
+                    </>
+                )}
+                {plan.features && (
+                    <ul className="mt0 mb2 unstyled">
+                        {plan.features.map((feature, i) => (
+                            <li key={i}>{feature}</li>
+                        ))}
+                    </ul>
+                )}
+                {isDisabled ? (
+                    <Tooltip title={c('Info').t`This plan is temporarily disabled`}>{button}</Tooltip>
+                ) : (
+                    button
+                )}
+            </div>
+        </div>
+    );
+};
+
+PlanCard.propTypes = {
+    isActive: PropTypes.bool.isRequired,
+    plan: PropTypes.shape({
+        image: PropTypes.node.isRequired,
+        planName: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        description: PropTypes.string,
+        additionalFeatures: PropTypes.string,
+        features: PropTypes.arrayOf(PropTypes.node),
+        highlights: PropTypes.arrayOf(PropTypes.string),
+        isBest: PropTypes.bool
+    }).isRequired,
+    cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.TWO_YEARS, CYCLE.YEARLY]).isRequired,
+    currency: PropTypes.oneOf(CURRENCIES).isRequired,
+    onSelect: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool
+};
+
+export default PlanCard;

--- a/containers/signup/PlanStep/PlanCard/PlanPrice.js
+++ b/containers/signup/PlanStep/PlanCard/PlanPrice.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { Price } from 'react-components';
+import { CYCLE, CURRENCIES } from 'proton-shared/lib/constants';
+
+const PlanPrice = ({ plan, cycle, currency }) => {
+    const discount = plan.couponDiscount || plan.price.saved;
+    const totalMonthlyPriceText = (
+        <span key="total-monthly" className="plan-price-area">
+            <Price className="inline-flex" currency={currency}>
+                {plan.price.totalMonthly}
+            </Price>
+        </span>
+    );
+    const totalBilledText =
+        cycle === CYCLE.MONTHLY ? (
+            <Price key="billed-price" currency={currency} suffix={c('Suffix').t`monthly`}>
+                {plan.price.totalMonthly}
+            </Price>
+        ) : (
+            <Price
+                key="billed-price"
+                currency={currency}
+                suffix={cycle === CYCLE.TWO_YEARS ? c('Suffix').t`/2-year` : c('Suffix').t`/year`}
+            >
+                {plan.price.total}
+            </Price>
+        );
+    const discountText = (
+        <Price key="discount" currency={currency}>
+            {discount}
+        </Price>
+    );
+    return (
+        <div className="border-top pt1 plan-price">
+            <div className="mb0-5">{c('PlanPrice').jt`${totalMonthlyPriceText} / mo`}</div>
+
+            <div>
+                <div className="opacity-50">{c('PlanPrice').jt`Billed as ${totalBilledText}`}</div>
+                {discount > 0 && <div className="bold color-primary">{c('PlanPrice').jt`SAVE ${discountText}`}</div>}
+            </div>
+        </div>
+    );
+};
+
+PlanPrice.propTypes = {
+    cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.TWO_YEARS, CYCLE.YEARLY]).isRequired,
+    currency: PropTypes.oneOf(CURRENCIES).isRequired,
+    plan: PropTypes.shape({
+        couponDiscount: PropTypes.number,
+        price: PropTypes.shape({
+            totalMonthly: PropTypes.number,
+            monthly: PropTypes.number,
+            total: PropTypes.number,
+            saved: PropTypes.number
+        }).isRequired
+    }).isRequired
+};
+
+export default PlanPrice;

--- a/containers/signup/PlanStep/PlanComparisonModal.js
+++ b/containers/signup/PlanStep/PlanComparisonModal.js
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { DialogModal, HeaderModal, InnerModal, usePlans } from 'react-components';
+import { c } from 'ttag';
+import { CYCLE, CURRENCIES } from 'proton-shared/lib/constants';
+
+const { MONTHLY, YEARLY, TWO_YEARS } = CYCLE;
+
+const PlanComparisonModal = ({
+    modalTitleID = 'modalTitle',
+    onClose,
+    defaultCycle,
+    defaultCurrency,
+    renderPlansTable,
+    ...rest
+}) => {
+    const [cycle, updateCycle] = useState(defaultCycle);
+    const [currency, updateCurrency] = useState(defaultCurrency);
+    const [plans, loading] = usePlans();
+
+    return (
+        <DialogModal onClose={onClose} className="pm-modal--wider" {...rest}>
+            <HeaderModal hasClose modalTitleID={modalTitleID} onClose={onClose}>
+                {c('Title').t`ProtonVPN plan comparison`}
+            </HeaderModal>
+            <div className="pm-modalContent">
+                <InnerModal>
+                    {renderPlansTable({ expand: true, loading, currency, cycle, updateCurrency, updateCycle, plans })}
+                </InnerModal>
+            </div>
+        </DialogModal>
+    );
+};
+
+PlanComparisonModal.propTypes = {
+    ...DialogModal.propTypes,
+    cycle: PropTypes.oneOf([MONTHLY, TWO_YEARS, YEARLY]).isRequired,
+    currency: PropTypes.oneOf(CURRENCIES).isRequired,
+    renderPlansTable: PropTypes.func.isRequired
+};
+
+export default PlanComparisonModal;

--- a/containers/signup/PlanStep/PlanStep.js
+++ b/containers/signup/PlanStep/PlanStep.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row, Field, CurrencySelector, CycleSelector, SubTitle, useModals, LinkButton } from 'react-components';
+import PlanCard from './PlanCard/PlanCard';
+import { CURRENCIES, CYCLE } from 'proton-shared/lib/constants';
+import { c } from 'ttag';
+import PlanComparisonModal from './PlanComparisonModal';
+import OSIcon from './OSIcon';
+import PlansGroupButtons from './PlansGroupButtons';
+
+const { MONTHLY, YEARLY, TWO_YEARS } = CYCLE;
+
+const PlanStep = ({
+    plans,
+    onSelectPlan,
+    onChangeCurrency,
+    onChangeCycle,
+    model,
+    signupAvailability,
+    renderPlansTable
+}) => {
+    const { createModal } = useModals();
+
+    const handleSelect = (planName) => () => onSelectPlan({ ...model, planName }, true);
+    const handleComparisonClick = () =>
+        createModal(
+            <PlanComparisonModal
+                renderPlansTable={renderPlansTable}
+                defaultCycle={model.cycle}
+                defaultCurrency={model.currency}
+            />
+        );
+
+    const supportedOS = (
+        <React.Fragment key="os">
+            <OSIcon os="android" />
+            <OSIcon os="windows" />
+            <OSIcon os="macos" />
+            <OSIcon os="ios" />
+            <OSIcon os="linux" />
+        </React.Fragment>
+    );
+
+    return (
+        <>
+            <Row className="flex-items-center pt2 mb2">
+                <div className="flex-item-fluid-auto">
+                    <SubTitle className="m0">{c('Title').t`Select a plan`}</SubTitle>
+                </div>
+                <div className="mlauto onmobile-alignright">
+                    <Field className="mr1 auto">
+                        <CycleSelector
+                            cycle={model.cycle}
+                            onSelect={onChangeCycle}
+                            options={[
+                                { text: c('Billing cycle option').t`Monthly`, value: MONTHLY },
+                                { text: c('Billing cycle option').t`Annually SAVE 20%`, value: YEARLY }
+                            ]}
+                        />
+                    </Field>
+                    <Field className="auto">
+                        <CurrencySelector currency={model.currency} onSelect={onChangeCurrency} />
+                    </Field>
+                </div>
+            </Row>
+            <div className="mb2 nodesktop notablet">
+                <PlansGroupButtons plans={plans} model={model} onSelectPlan={onSelectPlan} />
+            </div>
+            <div className="flex flex-nowrap">
+                {plans.map((plan) => (
+                    <PlanCard
+                        key={plan.planName}
+                        onSelect={handleSelect(plan.planName)}
+                        cycle={model.cycle}
+                        currency={model.currency}
+                        plan={plan}
+                        isActive={plan.planName === model.planName}
+                        isDisabled={plan.disabled || (!signupAvailability.paid && plan.price.monthly > 0)}
+                    />
+                ))}
+            </div>
+            {model.cycle === CYCLE.YEARLY && (
+                <strong className="mt2 bl big aligncenter color-primary">{c('Info')
+                    .t`You are saving 20% with an annual plan`}</strong>
+            )}
+            {model.cycle === CYCLE.TWO_YEARS && (
+                <strong className="mt2 bl big aligncenter color-primary">{c('Info')
+                    .t`You are saving 33% with an two-year plan`}</strong>
+            )}
+            <div className="mt2">
+                <LinkButton className="bl center" onClick={handleComparisonClick}>{c('Action')
+                    .t`View full plan comparison`}</LinkButton>
+            </div>
+            <div className="mt2 aligncenter">
+                <span>{c('Info').jt`All plans support: ${supportedOS}`}</span>
+                <span className="ml2 mr2 bordered" />
+                <span>{c('Info').t`30-days money back guarantee`}</span>
+            </div>
+        </>
+    );
+};
+
+PlanStep.propTypes = {
+    signupAvailability: PropTypes.shape({
+        paid: PropTypes.bool
+    }).isRequired,
+    plans: PropTypes.arrayOf(PropTypes.object).isRequired,
+    model: PropTypes.shape({
+        planName: PropTypes.string.isRequired,
+        cycle: PropTypes.oneOf([MONTHLY, TWO_YEARS, YEARLY]).isRequired,
+        currency: PropTypes.oneOf(CURRENCIES).isRequired
+    }).isRequired,
+    onSelectPlan: PropTypes.func.isRequired,
+    onChangeCycle: PropTypes.func.isRequired,
+    onChangeCurrency: PropTypes.func.isRequired,
+    renderPlansTable: PropTypes.func.isRequired
+};
+
+export default PlanStep;

--- a/containers/signup/PlanStep/PlansGroupButtons.js
+++ b/containers/signup/PlanStep/PlansGroupButtons.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Group, ButtonGroup, classnames } from 'react-components';
+import { CURRENCIES, CYCLE } from 'proton-shared/lib/constants';
+
+const { MONTHLY, YEARLY, TWO_YEARS } = CYCLE;
+
+const PlansGroupButtons = ({ plans, onSelectPlan, model, ...rest }) => {
+    return (
+        <Group {...rest} className="w100">
+            {plans.map(({ planName, title }) => {
+                return (
+                    <ButtonGroup
+                        key={planName}
+                        className={classnames(['flex-item-fluid', planName === model.planName && 'is-active'])}
+                        onClick={() => onSelectPlan({ ...model, planName })}
+                    >
+                        {title}
+                    </ButtonGroup>
+                );
+            })}
+        </Group>
+    );
+};
+
+PlansGroupButtons.propTypes = {
+    plans: PropTypes.arrayOf(PropTypes.object).isRequired,
+    onSelectPlan: PropTypes.func.isRequired,
+    model: PropTypes.shape({
+        planName: PropTypes.string.isRequired,
+        cycle: PropTypes.oneOf([MONTHLY, TWO_YEARS, YEARLY]).isRequired,
+        currency: PropTypes.oneOf(CURRENCIES).isRequired
+    }).isRequired
+};
+
+export default PlansGroupButtons;

--- a/containers/signup/SelectedPlan/PlanDetails.js
+++ b/containers/signup/SelectedPlan/PlanDetails.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { classnames } from 'react-components';
+import { PLAN } from '../plans';
+import PriceInfo from './PriceInfo';
+import { CYCLE, CURRENCIES } from 'proton-shared/lib/constants';
+
+const PlanDetails = ({ selectedPlan, cycle, currency }) => {
+    const { planName, title, additionalFeatures, features } = selectedPlan;
+    return (
+        <div className="flex flex-column bordered-container">
+            <h6 className="p0-5 mb0 w100 aligncenter color-primary">{c('Title').t`${title} plan details`}</h6>
+            <div className="p1">
+                <ul
+                    className={classnames([
+                        'selected-plan-list unstyled m0',
+                        !additionalFeatures && 'selected-plan-list--negative'
+                    ])}
+                >
+                    {additionalFeatures && <li>{additionalFeatures}</li>}
+                    {features.map((feature, i) => (
+                        <li key={i}>{feature}</li>
+                    ))}
+                </ul>
+                {planName !== PLAN.FREE && (
+                    <div className="border-top pt1 mt1">
+                        <PriceInfo plan={selectedPlan} cycle={cycle} currency={currency} />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+PlanDetails.propTypes = {
+    selectedPlan: PropTypes.object.isRequired,
+    cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.TWO_YEARS, CYCLE.YEARLY]).isRequired,
+    currency: PropTypes.oneOf(CURRENCIES).isRequired
+};
+
+export default PlanDetails;

--- a/containers/signup/SelectedPlan/PlanUpsell.js
+++ b/containers/signup/SelectedPlan/PlanUpsell.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { PLAN } from '../plans';
+import { PrimaryButton, Price } from 'react-components';
+import { CYCLE, CURRENCIES } from 'proton-shared/lib/constants';
+
+const PlanUpsell = ({ selectedPlan, getPlanByName, cycle, currency, onExtendCycle, onUpgrade }) => {
+    const { planName, upsell } = selectedPlan;
+    const upsellCycle = cycle === CYCLE.MONTHLY && planName !== PLAN.FREE;
+
+    if (!upsell && !upsellCycle) {
+        return null; // No upsell needed
+    }
+
+    const yearlyPlan = getPlanByName(selectedPlan.planName, CYCLE.YEARLY);
+    const upsellPlan = upsell && getPlanByName(upsell.planName);
+
+    const handleExtendCycle = () => onExtendCycle();
+    const handleUpgrade = () => onUpgrade(upsell.planName);
+
+    const totalMonthlyText = upsellPlan && (
+        <Price key="upgrade-price" currency={currency} suffix={c('Suffix').t`/ month`}>
+            {upsellPlan.price.totalMonthly}
+        </Price>
+    );
+
+    return (
+        <div className="flex mt1 flex-column bordered-container">
+            <h6 className="p0-5 mb0 w100 aligncenter color-primary">
+                {[PLAN.FREE, PLAN.BASIC].includes(planName)
+                    ? c('Title').t`Upgrade and get more`
+                    : c('Title').t`Summary`}
+            </h6>
+            <div className="p1">
+                {upsellCycle && (
+                    <>
+                        <div className="flex flex-spacebetween">
+                            <span className="mr0-25">{c('Plan upsell').t`Monthly plan`}</span>
+                            <s>
+                                <Price className="strike" currency={currency} suffix={c('Suffix').t`/ month`}>
+                                    {selectedPlan.price.totalMonthly}
+                                </Price>
+                            </s>
+                        </div>
+                        <div className="flex flex-spacebetween">
+                            <span className="mr0-25">{c('Plan upsell').t`Yearly plan`}</span>
+                            <Price currency={currency} suffix={c('Suffix').t`/ month`}>
+                                {yearlyPlan.price.totalMonthly}
+                            </Price>
+                        </div>
+                        <PrimaryButton className="w100 mt1" onClick={handleExtendCycle}>{c('Action')
+                            .t`Pay annually and save 20%`}</PrimaryButton>
+                    </>
+                )}
+
+                {upsell && !upsellCycle && (
+                    <>
+                        <ul className="selected-plan-list unstyled m0">
+                            {upsell.features.map((feature, i) => (
+                                <li key={i}>{feature}</li>
+                            ))}
+                        </ul>
+                        <PrimaryButton className="w100 mt1" onClick={handleUpgrade}>{c('Action')
+                            .jt`Try ${upsellPlan.title} for only ${totalMonthlyText}`}</PrimaryButton>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};
+
+PlanUpsell.propTypes = {
+    selectedPlan: PropTypes.object.isRequired,
+    cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.TWO_YEARS, CYCLE.YEARLY]).isRequired,
+    currency: PropTypes.oneOf(CURRENCIES).isRequired,
+    onExtendCycle: PropTypes.func.isRequired,
+    onUpgrade: PropTypes.func.isRequired,
+    getPlanByName: PropTypes.func.isRequired
+};
+
+export default PlanUpsell;

--- a/containers/signup/SelectedPlan/PriceInfo.js
+++ b/containers/signup/SelectedPlan/PriceInfo.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CYCLE, CURRENCIES } from 'proton-shared/lib/constants';
+import { c } from 'ttag';
+import { Price } from 'react-components';
+
+const PriceInfo = ({ plan, cycle, currency }) => {
+    const billingCycleI18n = {
+        [CYCLE.MONTHLY]: {
+            label: c('Label').t`1 month`,
+            total: c('Label').t`Total price`
+        },
+        [CYCLE.YEARLY]: {
+            label: c('Label').t`12 months`,
+            discount: c('Label').t`Annual discount (20%)`,
+            total: c('Label').t`Total price (annually)`
+        },
+        [CYCLE.TWO_YEARS]: {
+            label: c('Label').t`24 months`,
+            discount: c('Label').t`Two-year discount (33%)`,
+            total: c('Label').t`Total price (two-year)`
+        }
+    };
+
+    const billingCycle = billingCycleI18n[cycle];
+    const discount = plan.couponDiscount || plan.price.saved;
+
+    return (
+        <>
+            {plan.price.monthly > 0 && (
+                <div className="flex flex-spacebetween">
+                    <span className="mr0-25">
+                        {plan.title} - {billingCycle.label}
+                    </span>
+                    <Price currency={currency}>{plan.price.monthly * cycle}</Price>
+                </div>
+            )}
+            {(plan.couponDiscount || billingCycle.discount) && (
+                <div className="flex color-global-success flex-spacebetween">
+                    <span className="mr0-25">
+                        {plan.couponDiscount ? plan.couponDescription : billingCycle.discount}
+                    </span>
+                    <Price currency={currency}>{-discount}</Price>
+                </div>
+            )}
+            <strong className="flex flex-spacebetween">
+                <span className="mr0-25">{billingCycle.total}</span>
+                <Price currency={currency}>{plan.price.total}</Price>
+            </strong>
+        </>
+    );
+};
+
+PriceInfo.propTypes = {
+    plan: PropTypes.object.isRequired,
+    cycle: PropTypes.oneOf([CYCLE.MONTHLY, CYCLE.TWO_YEARS, CYCLE.YEARLY]).isRequired,
+    currency: PropTypes.oneOf(CURRENCIES).isRequired
+};
+
+export default PriceInfo;

--- a/containers/signup/SignupContainer.js
+++ b/containers/signup/SignupContainer.js
@@ -1,0 +1,245 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { Button, Title, useLoading, TextLoader, VpnLogo, Href, FullLoader, SupportDropdown } from 'react-components';
+import { checkCookie } from 'proton-shared/lib/helpers/cookies';
+import { CYCLE } from 'proton-shared/lib/constants';
+import AccountStep from './AccountStep/AccountStep';
+import PlanStep from './PlanStep/PlanStep';
+import useSignup from './useSignup';
+import VerificationStep from './VerificationStep/VerificationStep';
+import PaymentStep from './PaymentStep/PaymentStep';
+import { PLAN, VPN_PLANS, VPN_BEST_DEAL_PLANS } from './plans';
+import PlanDetails from './SelectedPlan/PlanDetails';
+import PlanUpsell from './SelectedPlan/PlanUpsell';
+import useVerification from './VerificationStep/useVerification';
+import MobileRedirectionStep from './MobileRedirectionStep/MobileRedirectionStep';
+
+const SignupState = {
+    Plan: 'plan',
+    Account: 'account',
+    Verification: 'verification',
+    Payment: 'payment',
+    MobileRedirection: 'mobile-redirection'
+};
+
+// TODO: Flexible urls and plans for reuse between project
+const SignupContainer = ({ match, history, onLogin, stopRedirect, renderPlansTable }) => {
+    const searchParams = new URLSearchParams(history.location.search);
+    const preSelectedPlan = searchParams.get('plan');
+    const redirectToMobile = searchParams.get('from') === 'mobile';
+    const availablePlans = checkCookie('offer', 'bestdeal') ? VPN_BEST_DEAL_PLANS : VPN_PLANS;
+
+    useEffect(() => {
+        document.title = c('Title').t`Sign up - ProtonVPN`;
+        // Always start at plans, or account if plan is preselected
+        if (preSelectedPlan) {
+            history.replace(`/signup/${SignupState.Account}`, history.location.state);
+        } else {
+            history.replace('/signup', history.location.state);
+        }
+    }, []);
+
+    const signupState = match.params.step;
+    const [upsellDone, setUpsellDone] = useState(false);
+    const [creatingAccount, withCreateLoading] = useLoading(false);
+    const historyState = history.location.state || {};
+    const invite = historyState.invite;
+    const coupon = historyState.coupon;
+
+    const goToStep = (step) => history.push(`/signup/${step}`);
+
+    const handleLogin = (...args) => {
+        if (redirectToMobile) {
+            return goToStep(SignupState.MobileRedirection);
+        }
+
+        stopRedirect();
+        history.push('/downloads');
+        onLogin(...args);
+    };
+
+    const {
+        model,
+        setModel,
+        signup,
+        selectedPlan,
+        makePayment,
+        signupAvailability,
+        getPlanByName,
+        isLoading,
+        appliedCoupon,
+        appliedInvite
+    } = useSignup(
+        handleLogin,
+        { coupon, invite, availablePlans },
+        {
+            planName: preSelectedPlan,
+            cycle: Number(searchParams.get('billing')),
+            currency: searchParams.get('currency')
+        }
+    );
+    const { verify, requestCode } = useVerification();
+
+    const handleSelectPlan = (model, next = false) => {
+        setModel(model);
+        next && goToStep(SignupState.Account);
+    };
+
+    const handleCreateAccount = async (model) => {
+        setModel(model);
+
+        if (selectedPlan.price.total > 0) {
+            goToStep(SignupState.Payment);
+        } else if (appliedInvite || appliedCoupon) {
+            await withCreateLoading(signup(model, { invite: appliedInvite, coupon: appliedCoupon }));
+        } else {
+            goToStep(SignupState.Verification);
+        }
+    };
+
+    const handleVerification = async (model, code, params) => {
+        const verificationToken = await verify(code, params);
+        await signup(model, { verificationToken });
+        setModel(model);
+    };
+
+    const handlePayment = async (model, paymentParameters = {}) => {
+        const paymentDetails = await makePayment(model, paymentParameters);
+        const { Payment = {} } = paymentParameters;
+        const { Type = '' } = Payment;
+        await withCreateLoading(signup(model, { paymentDetails, paymentMethodType: Type }));
+        setModel(model);
+    };
+
+    const handleUpgrade = (planName) => {
+        setModel({ ...model, planName });
+        setUpsellDone(true);
+        if (planName !== PLAN.FREE && signupState === SignupState.Verification) {
+            goToStep(SignupState.Payment);
+        } else if (planName === PLAN.FREE && signupState === SignupState.Payment) {
+            goToStep(SignupState.Verification);
+        }
+    };
+
+    const handleExtendCycle = () => {
+        setModel({ ...model, cycle: CYCLE.YEARLY });
+        setUpsellDone(true);
+    };
+
+    const selectedPlanComponent = (
+        <div className="ml2 onmobile-ml0 flex-item-fluid-auto onmobile-mt2 selected-plan">
+            <PlanDetails selectedPlan={selectedPlan} cycle={model.cycle} currency={model.currency} />
+            {!upsellDone && (
+                <PlanUpsell
+                    selectedPlan={selectedPlan}
+                    getPlanByName={getPlanByName}
+                    onExtendCycle={handleExtendCycle}
+                    onUpgrade={handleUpgrade}
+                    cycle={model.cycle}
+                    currency={model.currency}
+                />
+            )}
+        </div>
+    );
+
+    return (
+        <main className="flex flex-item-fluid main-area">
+            <div className="center p2 container-plans-signup onmobile-p1">
+                <div className="flex flex-nowrap flex-items-center onmobile-flex-wrap mb1">
+                    <div className="flex-item-fluid plan-back-button">
+                        {!creatingAccount &&
+                            (signupState && signupState !== SignupState.Plan ? (
+                                <Button onClick={() => history.goBack()}>{c('Action').t`Back`}</Button>
+                            ) : (
+                                <Href className="pm-button" url="https://protonvpn.com" target="_self">{c('Action')
+                                    .t`Homepage`}</Href>
+                            ))}
+                    </div>
+                    <div className="onmobile-min-w100 onmobile-aligncenter onmobile-mt0-5">
+                        <Href url="https://protonvpn.com" target="_self">
+                            <VpnLogo className="fill-primary" />
+                        </Href>
+                    </div>
+                    <div className="flex-item-fluid alignright plan-help-button">
+                        <SupportDropdown content={c('Action').t`Need help`} />
+                    </div>
+                </div>
+
+                <Title className="signup-title mt1-5">{c('Title').t`Sign up`}</Title>
+
+                {isLoading || creatingAccount ? (
+                    <div className="aligncenter mt2">
+                        <FullLoader color="pm-primary" size={200} />
+                        <TextLoader>{isLoading ? c('Info').t`Loading` : c('Info').t`Creating your account`}</TextLoader>
+                    </div>
+                ) : (
+                    <>
+                        {(!signupState || signupState === SignupState.Plan) && (
+                            <PlanStep
+                                renderPlansTable={renderPlansTable}
+                                plans={availablePlans.map((plan) => getPlanByName(plan))}
+                                model={model}
+                                onChangeCycle={(cycle) => setModel({ ...model, cycle })}
+                                onChangeCurrency={(currency) => setModel({ ...model, currency })}
+                                signupAvailability={signupAvailability}
+                                onSelectPlan={handleSelectPlan}
+                            />
+                        )}
+                        {signupState === SignupState.Account && (
+                            <AccountStep model={model} onContinue={handleCreateAccount}>
+                                {selectedPlanComponent}
+                            </AccountStep>
+                        )}
+                        {signupState === SignupState.Verification && (
+                            <VerificationStep
+                                model={model}
+                                allowedMethods={signupAvailability.allowedMethods}
+                                onVerify={(...rest) => withCreateLoading(handleVerification(...rest))}
+                                requestCode={requestCode}
+                            >
+                                {selectedPlanComponent}
+                            </VerificationStep>
+                        )}
+                        {signupState === SignupState.Payment && (
+                            <PaymentStep model={model} paymentAmount={selectedPlan.price.total} onPay={handlePayment}>
+                                {selectedPlanComponent}
+                            </PaymentStep>
+                        )}
+                        {signupState === SignupState.MobileRedirection && <MobileRedirectionStep model={model} />}
+                    </>
+                )}
+            </div>
+        </main>
+    );
+};
+
+SignupContainer.propTypes = {
+    stopRedirect: PropTypes.func.isRequired,
+    onLogin: PropTypes.func.isRequired,
+    match: PropTypes.shape({
+        params: PropTypes.shape({
+            step: PropTypes.string
+        })
+    }).isRequired,
+    renderPlansTable: PropTypes.func.isRequired,
+    history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+        goBack: PropTypes.func.isRequired,
+        replace: PropTypes.func.isRequired,
+        location: PropTypes.shape({
+            search: PropTypes.string.isRequired,
+            state: PropTypes.oneOfType([
+                PropTypes.shape({
+                    selector: PropTypes.string.isRequired,
+                    token: PropTypes.string.isRequired
+                }),
+                PropTypes.shape({
+                    Coupon: PropTypes.shape({ Code: PropTypes.string })
+                })
+            ])
+        }).isRequired
+    }).isRequired
+};
+
+export default SignupContainer;

--- a/containers/signup/SignupContainer.js
+++ b/containers/signup/SignupContainer.js
@@ -9,11 +9,12 @@ import PlanStep from './PlanStep/PlanStep';
 import useSignup from './useSignup';
 import VerificationStep from './VerificationStep/VerificationStep';
 import PaymentStep from './PaymentStep/PaymentStep';
-import { PLAN, VPN_PLANS, VPN_BEST_DEAL_PLANS } from './plans';
+import { PLAN, getAvailablePlans } from './plans';
 import PlanDetails from './SelectedPlan/PlanDetails';
 import PlanUpsell from './SelectedPlan/PlanUpsell';
 import useVerification from './VerificationStep/useVerification';
 import MobileRedirectionStep from './MobileRedirectionStep/MobileRedirectionStep';
+import useConfig from '../config/useConfig';
 
 const SignupState = {
     Plan: 'plan',
@@ -25,10 +26,11 @@ const SignupState = {
 
 // TODO: Flexible urls and plans for reuse between project
 const SignupContainer = ({ match, history, onLogin, stopRedirect, renderPlansTable }) => {
+    const { CLIENT_TYPE } = useConfig();
     const searchParams = new URLSearchParams(history.location.search);
     const preSelectedPlan = searchParams.get('plan');
     const redirectToMobile = searchParams.get('from') === 'mobile';
-    const availablePlans = checkCookie('offer', 'bestdeal') ? VPN_BEST_DEAL_PLANS : VPN_PLANS;
+    const availablePlans = getAvailablePlans(CLIENT_TYPE, checkCookie('offer', 'bestdeal'));
 
     useEffect(() => {
         document.title = c('Title').t`Sign up - ProtonVPN`;

--- a/containers/signup/VerificationStep/VerificationForm/VerificationCodeForm/ResendCodeModal.js
+++ b/containers/signup/VerificationStep/VerificationForm/VerificationCodeForm/ResendCodeModal.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DialogModal, HeaderModal, InnerModal, FooterModal, PrimaryButton, Button } from 'react-components';
+import { c } from 'ttag';
+
+const ResendCodeModal = ({ modalTitleID = 'modalTitle', onResend, onBack, destination, onClose, ...rest }) => {
+    const editI18n = c('Action').t`Edit`;
+    const destinationText = <strong key="destination">{destination.Address || destination.Phone}</strong>;
+    const destinationType = destination.Address ? c('VerificationType').t`email` : c('VerificationType').t`phone`;
+
+    return (
+        <DialogModal modalTitleID={modalTitleID} onClose={onClose} {...rest}>
+            <HeaderModal hasClose modalTitleID={modalTitleID} onClose={onClose}>
+                {c('Title').t`Resend code`}
+            </HeaderModal>
+            <div className="pm-modalContent">
+                <InnerModal>
+                    <p>
+                        {c('Info')
+                            .jt`Click below to resend the code to ${destinationText}. If ${destinationType} is incorrect, please click "${editI18n}".`}
+                    </p>
+                </InnerModal>
+                <FooterModal>
+                    <div className="flex w100 flex-spacebetween">
+                        <Button onClick={onClose}>{c('Action').t`Cancel`}</Button>
+                        <div>
+                            <Button
+                                className="mr1"
+                                onClick={() => {
+                                    onBack();
+                                    onClose();
+                                }}
+                            >
+                                {editI18n}
+                            </Button>
+                            <PrimaryButton
+                                onClick={() => {
+                                    onResend();
+                                    onClose();
+                                }}
+                            >{c('Action').t`Resend`}</PrimaryButton>
+                        </div>
+                    </div>
+                </FooterModal>
+            </div>
+        </DialogModal>
+    );
+};
+
+ResendCodeModal.propTypes = {
+    modalTitleID: PropTypes.string,
+    destination: PropTypes.shape({
+        Phone: PropTypes.string,
+        Address: PropTypes.string
+    }).isRequired,
+    onResend: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
+    onBack: PropTypes.func
+};
+
+export default ResendCodeModal;

--- a/containers/signup/VerificationStep/VerificationForm/VerificationCodeForm/VerificationCodeForm.js
+++ b/containers/signup/VerificationStep/VerificationForm/VerificationCodeForm/VerificationCodeForm.js
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+    Row,
+    Field,
+    Input,
+    PrimaryButton,
+    Label,
+    InlineLinkButton,
+    useLoading,
+    Alert,
+    useModals
+} from 'react-components';
+import { c } from 'ttag';
+import ResendCodeModal from './ResendCodeModal';
+
+const VerificationCodeForm = ({ onSubmit, onResend, onBack, destination }) => {
+    const { createModal } = useModals();
+    const [loading, withLoading] = useLoading();
+    const [code, setCode] = useState('');
+    const destinationText = <strong key="destination">{destination.Address || destination.Phone}</strong>;
+
+    const handleResend = () => {
+        createModal(<ResendCodeModal onBack={onBack} onResend={onResend} destination={destination} />);
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        withLoading(onSubmit(code));
+    };
+
+    const handleChangeCode = ({ target }) => setCode(target.value);
+
+    return (
+        <div>
+            <h3>{c('Title').t`Enter verification code`}</h3>
+            <Alert>
+                <div>{c('Info').jt`Enter the verification code that was sent to ${destinationText}.`}</div>
+                {destination.Address ? (
+                    <div>{c('Info').t`If you don't find the email in your inbox, please check your spam folder.`}</div>
+                ) : null}
+            </Alert>
+            <form onSubmit={handleSubmit}>
+                <Row>
+                    <Label htmlFor="code">{c('Label').t`6-digit code`}</Label>
+                    <Field className="mr1 auto flex-item-fluid">
+                        <Input
+                            id="code"
+                            className="mb1"
+                            value={code}
+                            onChange={handleChangeCode}
+                            placeholder="123456"
+                            autoFocus={true}
+                            required
+                        />
+                        <div className="mb1">
+                            <PrimaryButton disabled={!code} type="submit" loading={loading}>{c('Action')
+                                .t`Verify`}</PrimaryButton>
+                        </div>
+                        <div className="mb1">
+                            <InlineLinkButton onClick={handleResend}>{c('Action')
+                                .t`Did not receive the code?`}</InlineLinkButton>
+                        </div>
+                        <div>
+                            <InlineLinkButton className="mr0-5" onClick={onBack}>{c('Action')
+                                .t`Use another verification method`}</InlineLinkButton>
+                        </div>
+                    </Field>
+                </Row>
+            </form>
+        </div>
+    );
+};
+
+VerificationCodeForm.propTypes = {
+    onSubmit: PropTypes.func.isRequired,
+    onResend: PropTypes.func.isRequired,
+    onBack: PropTypes.func.isRequired,
+    destination: PropTypes.shape({
+        Phone: PropTypes.string,
+        Address: PropTypes.string
+    })
+};
+
+export default VerificationCodeForm;

--- a/containers/signup/VerificationStep/VerificationForm/VerificationForm.js
+++ b/containers/signup/VerificationStep/VerificationForm/VerificationForm.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useNotifications } from 'react-components';
+import VerificationMethodForm from './VerificationMethodForm/VerificationMethodForm';
+import VerificationCodeForm from './VerificationCodeForm/VerificationCodeForm';
+import { c } from 'ttag';
+
+const VerificationForm = ({ defaultEmail, allowedMethods, onRequestCode, onSubmit }) => {
+    const { createNotification } = useNotifications();
+    const [params, setParams] = useState(null);
+
+    const handleBack = () => setParams(null);
+
+    const sendCode = async (params) => {
+        const destination = params.Destination.Phone || params.Destination.Address;
+        await onRequestCode(params);
+        createNotification({ text: c('Notification').t`Verification code successfully sent to ${destination}` });
+    };
+
+    const handleResendCode = () => sendCode(params);
+
+    const handleRequestCode = async (params) => {
+        await sendCode(params);
+        setParams(params);
+    };
+
+    const handleSubmitCode = (code) => onSubmit(code, params);
+
+    if (!params) {
+        return (
+            <VerificationMethodForm
+                defaultEmail={defaultEmail}
+                allowedMethods={allowedMethods}
+                onSubmit={handleRequestCode}
+            />
+        );
+    }
+
+    return (
+        <VerificationCodeForm
+            destination={params.Destination}
+            onSubmit={handleSubmitCode}
+            onBack={handleBack}
+            onResend={handleResendCode}
+        />
+    );
+};
+
+VerificationForm.propTypes = {
+    onSubmit: PropTypes.func.isRequired,
+    onRequestCode: PropTypes.func.isRequired,
+    defaultEmail: PropTypes.string.isRequired,
+    allowedMethods: PropTypes.arrayOf(PropTypes.string).isRequired
+};
+
+export default VerificationForm;

--- a/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationEmailInput.js
+++ b/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationEmailInput.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { PrimaryButton, EmailInput } from 'react-components';
+import { c } from 'ttag';
+
+const VerificationEmailInput = ({ defaultEmail = '', onSendClick, loading }) => {
+    const [email, setEmail] = useState(defaultEmail);
+
+    const handleChange = ({ target }) => setEmail(target.value);
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        onSendClick(email);
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <div className="mb1">
+                <EmailInput value={email} onChange={handleChange} placeholder={c('Placeholder').t`Email`} />
+            </div>
+            <div>
+                <PrimaryButton type="submit" disabled={!email} loading={loading}>{c('Action').t`Send`}</PrimaryButton>
+            </div>
+        </form>
+    );
+};
+
+VerificationEmailInput.propTypes = {
+    onSendClick: PropTypes.func.isRequired,
+    defaultEmail: PropTypes.string,
+    loading: PropTypes.bool
+};
+
+export default VerificationEmailInput;

--- a/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationMethodForm.js
+++ b/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationMethodForm.js
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Row, useLoading, Radio, Label, Field } from 'react-components';
+import { c } from 'ttag';
+import VerificationEmailInput from './VerificationEmailInput';
+import VerificationPhoneInput from './VerificationPhoneInput';
+import { TOKEN_TYPES } from 'proton-shared/lib/constants';
+
+const VERIFICATION_METHOD = {
+    EMAIL: TOKEN_TYPES.EMAIL,
+    SMS: TOKEN_TYPES.SMS
+};
+
+const VerificationMethodForm = ({ defaultEmail, allowedMethods, onSubmit }) => {
+    const isMethodAllowed = (method) => allowedMethods.includes(method);
+    const defaultMethod = Object.values(VERIFICATION_METHOD).find(isMethodAllowed);
+
+    const [loading, withLoading] = useLoading();
+    const [method, setMethod] = useState(defaultMethod);
+
+    const handleSendEmailCode = (Address) =>
+        withLoading(onSubmit({ Type: VERIFICATION_METHOD.EMAIL, Destination: { Address } }));
+    const handleSendSMSCode = (Phone) =>
+        withLoading(onSubmit({ Type: VERIFICATION_METHOD.SMS, Destination: { Phone } }));
+
+    const handleSelectMethod = (method) => () => setMethod(method);
+
+    return (
+        <div>
+            <h3>{c('Title').t`Select an account verification method`}</h3>
+
+            {allowedMethods.length ? (
+                <Row>
+                    <Label>{c('Label').t`Verification method`}</Label>
+                    <Field className="auto flex-item-fluid-auto">
+                        <div className="pt0-5 mb1">
+                            {isMethodAllowed(VERIFICATION_METHOD.EMAIL) ? (
+                                <Radio
+                                    className="mr1"
+                                    checked={method === VERIFICATION_METHOD.EMAIL}
+                                    onChange={handleSelectMethod(VERIFICATION_METHOD.EMAIL)}
+                                >{c('Option').t`Email address`}</Radio>
+                            ) : null}
+                            {isMethodAllowed(VERIFICATION_METHOD.SMS) && (
+                                <Radio
+                                    checked={method === VERIFICATION_METHOD.SMS}
+                                    onChange={handleSelectMethod(VERIFICATION_METHOD.SMS)}
+                                >{c('Option').t`SMS`}</Radio>
+                            )}
+                        </div>
+                        <div>
+                            {method === VERIFICATION_METHOD.EMAIL && (
+                                <VerificationEmailInput
+                                    loading={loading}
+                                    defaultEmail={defaultEmail}
+                                    onSendClick={handleSendEmailCode}
+                                />
+                            )}
+                            {method === VERIFICATION_METHOD.SMS && (
+                                <VerificationPhoneInput loading={loading} onSendClick={handleSendSMSCode} />
+                            )}
+                        </div>
+                    </Field>
+                </Row>
+            ) : null}
+        </div>
+    );
+};
+
+VerificationMethodForm.propTypes = {
+    defaultEmail: PropTypes.string.isRequired,
+    allowedMethods: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onSubmit: PropTypes.func.isRequired
+};
+
+export default VerificationMethodForm;

--- a/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationMethodSelector.js
+++ b/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationMethodSelector.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Select } from 'react-components';
+
+const VerificationMethodSelector = ({ allowedMethods, method, onSelect, ...rest }) => {
+    const handleChange = ({ target }) => onSelect(target.value);
+    const options = allowedMethods.map((c) => ({ text: c, value: c }));
+
+    return <Select value={method} options={options} onChange={handleChange} {...rest} />;
+};
+
+VerificationMethodSelector.propTypes = {
+    allowedMethods: PropTypes.arrayOf(PropTypes.string).isRequired,
+    method: PropTypes.string,
+    onSelect: PropTypes.func.isRequired
+};
+
+export default VerificationMethodSelector;

--- a/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationPhoneInput.js
+++ b/containers/signup/VerificationStep/VerificationForm/VerificationMethodForm/VerificationPhoneInput.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { PrimaryButton, IntlTelInput } from 'react-components';
+import { c } from 'ttag';
+
+const VerificationPhoneInput = ({ onSendClick, loading }) => {
+    const [phone, setPhone] = useState('');
+
+    const handleChangePhone = (status, value, countryData, number) => {
+        setPhone(number);
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        onSendClick(phone);
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <div className="mb1">
+                <IntlTelInput
+                    containerClassName="w100"
+                    inputClassName="w100"
+                    onPhoneNumberChange={handleChangePhone}
+                    onPhoneNumberBlur={handleChangePhone}
+                />
+            </div>
+            <div>
+                <PrimaryButton type="submit" disabled={!phone} loading={loading}>{c('Action').t`Send`}</PrimaryButton>
+            </div>
+        </form>
+    );
+};
+
+VerificationPhoneInput.propTypes = {
+    onSendClick: PropTypes.func.isRequired,
+    loading: PropTypes.bool
+};
+
+export default VerificationPhoneInput;

--- a/containers/signup/VerificationStep/VerificationStep.js
+++ b/containers/signup/VerificationStep/VerificationStep.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row, Alert, SubTitle } from 'react-components';
+import VerificationForm from './VerificationForm/VerificationForm';
+import { c } from 'ttag';
+
+import LoginPanel from '../LoginPanel';
+
+const VerificationStep = ({ onVerify, requestCode, allowedMethods, model, children }) => {
+    const handleSubmit = async (code, params) => {
+        const newEmail = params.Destination.Address;
+
+        await onVerify(
+            { ...model, email: newEmail && newEmail !== model.email ? newEmail : model.email },
+            code,
+            params
+        );
+    };
+
+    return (
+        <div className="pt2 mb2">
+            <SubTitle>{c('Title').t`Are you human?`}</SubTitle>
+            <Row className="auto flex-item-fluid-auto">
+                <div className="w100">
+                    <Alert>{c('Info')
+                        .t`To prevent misuse, please verify you are human. Please do not close this tab until you have verified your account.`}</Alert>
+                    <VerificationForm
+                        allowedMethods={allowedMethods}
+                        defaultEmail={model.email}
+                        onRequestCode={requestCode}
+                        onSubmit={handleSubmit}
+                    />
+                    <LoginPanel />
+                </div>
+                {children}
+            </Row>
+        </div>
+    );
+};
+
+VerificationStep.propTypes = {
+    model: PropTypes.shape({
+        email: PropTypes.string
+    }).isRequired,
+    allowedMethods: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onVerify: PropTypes.func.isRequired,
+    requestCode: PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired
+};
+
+export default VerificationStep;

--- a/containers/signup/VerificationStep/useVerification.js
+++ b/containers/signup/VerificationStep/useVerification.js
@@ -1,0 +1,19 @@
+import { useConfig, useApi } from 'react-components';
+import { queryCheckVerificationCode, queryVerificationCode } from 'proton-shared/lib/api/user';
+
+const useVerification = () => {
+    const api = useApi();
+    const { CLIENT_TYPE } = useConfig();
+    const requestCode = ({ Type, Destination }) => api(queryVerificationCode(Type, Destination));
+
+    const verify = async (code, { Type: TokenType, Destination }) => {
+        const Token = `${Destination.Phone || Destination.Address}:${code}`;
+        const verificationToken = { Token, TokenType };
+        await api(queryCheckVerificationCode(Token, TokenType, CLIENT_TYPE));
+        return verificationToken;
+    };
+
+    return { verify, requestCode };
+};
+
+export default useVerification;

--- a/containers/signup/plans.tsx
+++ b/containers/signup/plans.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { c, msgid } from 'ttag';
+import { PLAN_TYPES, CYCLE, CLIENT_TYPES } from 'proton-shared/lib/constants';
+import freePlanSvg from 'design-system/assets/img/pv-images/plans/free.svg';
+import basicPlanSvg from 'design-system/assets/img/pv-images/plans/basic.svg';
+import plusPlanSvg from 'design-system/assets/img/pv-images/plans/plus.svg';
+import visionaryPlanSvg from 'design-system/assets/img/pv-images/plans/visionary.svg';
+import Info from '../../components/link/Info';
+
+interface PlanCountries {
+    free: string[];
+    basic: string[];
+    all: string[];
+}
+
+export enum PLAN {
+    FREE = 'free',
+    PLUS = 'plus',
+    PROFESSIONAL = 'professional',
+    VISIONARY = 'visionary',
+    VPNBASIC = 'vpnbasic',
+    VPNPLUS = 'vpnplus'
+}
+
+export const PLAN_NAMES = {
+    [PLAN.FREE]: 'Free',
+    [PLAN.VISIONARY]: 'Visionary',
+    [PLAN.VPNBASIC]: 'Basic',
+    [PLAN.VPNPLUS]: 'Plus',
+    [PLAN.PLUS]: 'Plus',
+    [PLAN.PROFESSIONAL]: 'Professional'
+};
+
+type VPNPlans = PLAN.FREE | PLAN.VPNBASIC | PLAN.VPNPLUS | PLAN.VISIONARY;
+
+export const VPN_PLANS = [PLAN.FREE, PLAN.VPNBASIC, PLAN.VPNPLUS, PLAN.VISIONARY];
+export const MAIL_PLANS = [PLAN.FREE, PLAN.PLUS, PLAN.VISIONARY, PLAN.PROFESSIONAL];
+export const VPN_BEST_DEAL_PLANS = [PLAN.VPNBASIC, PLAN.VPNPLUS, PLAN.VISIONARY];
+
+export const getPlusPlan = (clientType: CLIENT_TYPES) => (clientType === CLIENT_TYPES.VPN ? PLAN.VPNPLUS : PLAN.PLUS);
+
+const getVPNPlanFeatures = (plan: VPNPlans, maxConnections: number, countries: PlanCountries) =>
+    ({
+        [PLAN.FREE]: {
+            image: <img width={13} src={freePlanSvg} alt={`${PLAN_NAMES[PLAN.FREE]} plan image`} />,
+            description: c('Plan Description').t`Privacy and security for everyone`,
+            upsell: {
+                planName: PLAN.VPNBASIC,
+                features: [
+                    c('Plan Feature').t`High speed 1 Gbps VPN servers`,
+                    c('Plan Feature').t`Access to ${countries.basic.length} countries`,
+                    c('Plan Feature').t`Filesharing/P2P support`
+                ]
+            },
+            features: [
+                c('Plan Feature').ngettext(
+                    msgid`${maxConnections} simultaneous VPN connection`,
+                    `${maxConnections} simultaneous VPN connections`,
+                    maxConnections
+                ),
+                c('Plan Feature').t`Servers in ${countries.free.length} countries`,
+                c('Plan Feature').t`Medium speed`,
+                c('Plan Feature').t`No logs policy`,
+                c('Plan Feature').t`No data limit`,
+                c('Plan Feature').t`No ads`
+            ]
+        },
+        [PLAN.VPNBASIC]: {
+            image: <img width={60} src={basicPlanSvg} alt={`${PLAN_NAMES[PLAN.VPNBASIC]} plan image`} />,
+            description: c('Plan Description').t`Basic privacy features`,
+            additionalFeatures: c('Plan feature').t`All ${PLAN_NAMES[PLAN.FREE]} plan features`,
+            upsell: {
+                planName: PLAN.VPNPLUS,
+                features: [
+                    c('Plan Feature').t`Highest speed servers (10 Gbps)`,
+                    c('Plan Feature').t`Access blocked content`,
+                    c('Plan Feature').t`All advanced security features`
+                ]
+            },
+            features: [
+                c('Plan Feature').ngettext(
+                    msgid`${maxConnections} simultaneous VPN connection`,
+                    `${maxConnections} simultaneous VPN connections`,
+                    maxConnections
+                ),
+                c('Plan Feature').t`Servers in ${countries.basic.length} countries`,
+                c('Plan Feature').t`High speed servers`,
+                <>
+                    <span className="mr0-5">{c('Plan Feature').t`Filesharing/P2P support`}</span>
+                    <Info title={c('Tooltip').t`Support for file sharing protocols such as Bittorrent.`} />
+                </>,
+                c('Plan Feature').t`No logs policy`
+            ]
+        },
+        [PLAN.VPNPLUS]: {
+            image: <img width={60} src={plusPlanSvg} alt={`${PLAN_NAMES[PLAN.VPNPLUS]} plan image`} />,
+            isBest: true,
+            description: c('Plan Description').t`Advanced security features`,
+            additionalFeatures: c('Plan feature').t`All ${PLAN_NAMES[PLAN.VPNBASIC]} plan features`,
+            features: [
+                c('Plan Feature').ngettext(
+                    msgid`${maxConnections} simultaneous VPN connection`,
+                    `${maxConnections} simultaneous VPN connections`,
+                    maxConnections
+                ),
+                countries.basic.length !== countries.all.length &&
+                    c('Plan Feature').t`Servers in ${countries.all.length} countries`,
+                c('Plan Feature').t`Secure Core`,
+                c('Plan Feature').t`Highest speeds`,
+                <>
+                    <span className="mr0-5">{c('Plan Feature').t`Access blocked content`}</span>
+                    <Info
+                        title={c('Tooltip')
+                            .t`Access content (Netflix, Amazon Prime, Wikipedia, Facebook, Youtube, etc) no matter where you are.`}
+                    />
+                </>,
+                c('Plan Feature').t`All advanced security features`
+            ]
+        },
+        [PLAN.VISIONARY]: {
+            image: <img width={100} src={visionaryPlanSvg} alt={`${PLAN_NAMES[PLAN.VISIONARY]} plan image`} />,
+            description: c('Plan Description').t`The complete privacy suite`,
+            additionalFeatures: c('Plan feature').t`All ${PLAN_NAMES[PLAN.VPNPLUS]} plan features`,
+            features: [
+                c('Plan Feature').ngettext(
+                    msgid`${maxConnections} simultaneous VPN connection`,
+                    `${maxConnections} simultaneous VPN connections`,
+                    maxConnections
+                ),
+                c('Plan Feature').t`ProtonMail Visionary account`
+            ]
+        }
+    }[plan]);
+
+// To use coupon, AmountDue from coupon must be merged into plan.
+const getPlanPrice = (plan: any, cycle: number) => {
+    const monthly = plan.Pricing[CYCLE.MONTHLY];
+    const cyclePrice = plan.Pricing[cycle];
+    const adjustedTotal = plan.AmountDue;
+
+    const total = typeof adjustedTotal !== 'undefined' ? adjustedTotal : cyclePrice;
+    const saved = monthly * cycle - cyclePrice;
+    const totalMonthly = total / cycle;
+
+    return { monthly, total, totalMonthly, saved };
+};
+
+// TODO: Hhigher order function with client type
+export const getVPNPlan = (
+    planName: VPNPlans,
+    cycle: number,
+    plans: any = [],
+    countries: PlanCountries = { free: [], basic: [], all: [] }
+) => {
+    const plan = plans.find(({ Type, Name }: any) => Type === PLAN_TYPES.PLAN && Name === planName);
+    const price = plan ? getPlanPrice(plan, cycle) : { monthly: 0, total: 0, totalMonthly: 0, saved: 0 };
+    return {
+        ...getVPNPlanFeatures(planName, plan ? plan.MaxVPN : 1, countries),
+        planName,
+        title: PLAN_NAMES[planName],
+        id: plan && plan.ID,
+        disabled: !plan && planName !== PLAN.FREE,
+        price,
+        couponDiscount: plan && Math.abs(plan.CouponDiscount),
+        couponDescription: plan && plan.CouponDescription
+    };
+};

--- a/containers/signup/plans.tsx
+++ b/containers/signup/plans.tsx
@@ -36,7 +36,7 @@ export const VPN_PLANS = [PLAN.FREE, PLAN.VPNBASIC, PLAN.VPNPLUS, PLAN.VISIONARY
 export const VPN_BEST_DEAL_PLANS = [PLAN.VPNBASIC, PLAN.VPNPLUS, PLAN.VISIONARY];
 
 type MailPlans = PLAN.FREE | PLAN.PLUS | PLAN.VISIONARY | PLAN.PROFESSIONAL;
-export const MAIL_PLANS = [PLAN.FREE, PLAN.PLUS, PLAN.VISIONARY, PLAN.PROFESSIONAL];
+export const MAIL_PLANS = [PLAN.FREE, PLAN.PLUS, PLAN.PROFESSIONAL, PLAN.VISIONARY];
 
 export const getPlusPlan = (clientType: CLIENT_TYPES) => (clientType === CLIENT_TYPES.VPN ? PLAN.VPNPLUS : PLAN.PLUS);
 
@@ -141,6 +141,70 @@ const getVPNPlanFeatures = (plan: VPNPlans, maxConnections: number, countries: P
         }
     }[plan]);
 
+const getMailPlanFeatures = (plan: MailPlans) =>
+    ({
+        [PLAN.FREE]: {
+            image: <div>FREE PLAN IMAGE</div>,
+            description: c('Plan Description').t`Free plan description`,
+            upsell: {
+                planName: PLAN.PLUS,
+                features: [
+                    c('Plan Feature').t`Upsell feature 1`,
+                    c('Plan Feature').t`Upsell feature 2`,
+                    c('Plan Feature').t`Upsell feature 3`
+                ]
+            },
+            features: [
+                c('Plan Feature').t`Feature 1`,
+                c('Plan Feature').t`Feature 2`,
+                c('Plan Feature').t`Feature 3`,
+                c('Plan Feature').t`Feature 4`
+            ]
+        },
+        [PLAN.PLUS]: {
+            image: <div>PLUS PLAN IMAGE</div>,
+            isBest: true,
+            description: c('Plan Description').t`Plus plan description`,
+            additionalFeatures: c('Plan feature').t`All ${PLAN_NAMES[PLAN.FREE]} plan features`,
+            upsell: {
+                planName: PLAN.PROFESSIONAL,
+                features: [
+                    c('Plan Feature').t`Upsell feature 1`,
+                    c('Plan Feature').t`Upsell feature 2`,
+                    c('Plan Feature').t`Upsell feature 3`
+                ]
+            },
+            features: [
+                c('Plan Feature').t`Feature 1`,
+                c('Plan Feature').t`Feature 2`,
+                c('Plan Feature').t`Feature 3`,
+                c('Plan Feature').t`Feature 4`
+            ]
+        },
+        [PLAN.PROFESSIONAL]: {
+            image: <div>PROFESSIONAL PLAN IMAGE</div>,
+            description: c('Plan Description').t`Professional plan description`,
+            additionalFeatures: c('Plan feature').t`All ${PLAN_NAMES[PLAN.PLUS]} plan features`,
+            features: [
+                c('Plan Feature').t`Feature 1`,
+                c('Plan Feature').t`Feature 2`,
+                c('Plan Feature').t`Feature 3`,
+                c('Plan Feature').t`Feature 4`
+            ]
+        },
+        [PLAN.VISIONARY]: {
+            image: <div>VISIONARY PLAN IMAGE</div>,
+            description: c('Plan Description').t`Visionary plan description`,
+            additionalFeatures: c('Plan feature').t`All ${PLAN_NAMES[PLAN.PROFESSIONAL]} plan features`,
+            features: [
+                c('Plan Feature').t`Feature 1`,
+                c('Plan Feature').t`Feature 2`,
+                c('Plan Feature').t`Feature 3`,
+                c('Plan Feature').t`Feature 4`
+            ]
+        }
+    }[plan]);
+
 // To use coupon, AmountDue from coupon must be merged into plan.
 const getPlanPrice = (plan: any, cycle: number) => {
     const monthly = plan.Pricing[CYCLE.MONTHLY];
@@ -168,7 +232,7 @@ export const getPlan = (
     const planFeatures =
         clientType === CLIENT_TYPES.VPN
             ? getVPNPlanFeatures(planName as VPNPlans, plan ? plan.MaxVPN : 1, countries)
-            : {};
+            : getMailPlanFeatures(planName as MailPlans);
 
     return {
         ...planFeatures,

--- a/containers/signup/plans.tsx
+++ b/containers/signup/plans.tsx
@@ -32,12 +32,21 @@ export const PLAN_NAMES = {
 };
 
 type VPNPlans = PLAN.FREE | PLAN.VPNBASIC | PLAN.VPNPLUS | PLAN.VISIONARY;
-
 export const VPN_PLANS = [PLAN.FREE, PLAN.VPNBASIC, PLAN.VPNPLUS, PLAN.VISIONARY];
-export const MAIL_PLANS = [PLAN.FREE, PLAN.PLUS, PLAN.VISIONARY, PLAN.PROFESSIONAL];
 export const VPN_BEST_DEAL_PLANS = [PLAN.VPNBASIC, PLAN.VPNPLUS, PLAN.VISIONARY];
 
+type MailPlans = PLAN.FREE | PLAN.PLUS | PLAN.VISIONARY | PLAN.PROFESSIONAL;
+export const MAIL_PLANS = [PLAN.FREE, PLAN.PLUS, PLAN.VISIONARY, PLAN.PROFESSIONAL];
+
 export const getPlusPlan = (clientType: CLIENT_TYPES) => (clientType === CLIENT_TYPES.VPN ? PLAN.VPNPLUS : PLAN.PLUS);
+
+export const getAvailablePlans = (clientType: CLIENT_TYPES, bestDeal?: boolean) => {
+    if (clientType === CLIENT_TYPES.VPN) {
+        return bestDeal ? VPN_BEST_DEAL_PLANS : VPN_PLANS;
+    }
+
+    return MAIL_PLANS;
+};
 
 const getVPNPlanFeatures = (plan: VPNPlans, maxConnections: number, countries: PlanCountries) =>
     ({
@@ -145,17 +154,24 @@ const getPlanPrice = (plan: any, cycle: number) => {
     return { monthly, total, totalMonthly, saved };
 };
 
-// TODO: Hhigher order function with client type
-export const getVPNPlan = (
-    planName: VPNPlans,
+export const getPlan = (
+    clientType: CLIENT_TYPES,
+    planName: VPNPlans | MailPlans,
     cycle: number,
     plans: any = [],
     countries: PlanCountries = { free: [], basic: [], all: [] }
 ) => {
     const plan = plans.find(({ Type, Name }: any) => Type === PLAN_TYPES.PLAN && Name === planName);
     const price = plan ? getPlanPrice(plan, cycle) : { monthly: 0, total: 0, totalMonthly: 0, saved: 0 };
+
+    // TODO: get Mail plan features
+    const planFeatures =
+        clientType === CLIENT_TYPES.VPN
+            ? getVPNPlanFeatures(planName as VPNPlans, plan ? plan.MaxVPN : 1, countries)
+            : {};
+
     return {
-        ...getVPNPlanFeatures(planName, plan ? plan.MaxVPN : 1, countries),
+        ...planFeatures,
         planName,
         title: PLAN_NAMES[planName],
         id: plan && plan.ID,

--- a/containers/signup/useSignup.js
+++ b/containers/signup/useSignup.js
@@ -1,15 +1,6 @@
 import { useState, useEffect } from 'react';
 import { handlePaymentToken } from 'react-components/containers/payments/paymentTokenHelper';
 import { srpVerify, srpAuth } from 'proton-shared/lib/srp';
-import {
-    useApi,
-    usePlans,
-    useConfig,
-    useApiResult,
-    useModals,
-    useVPNCountries,
-    useNotifications
-} from 'react-components';
 import { queryCreateUser, queryDirectSignupStatus } from 'proton-shared/lib/api/user';
 import { auth, setCookies } from 'proton-shared/lib/api/auth';
 import { subscribe, setPaymentMethod, verifyPayment, checkSubscription } from 'proton-shared/lib/api/payments';
@@ -24,8 +15,15 @@ import {
     CURRENCIES,
     PAYMENT_METHOD_TYPES
 } from 'proton-shared/lib/constants';
-import { getVPNPlan, PLAN, getPlusPlan } from './plans';
+import { getPlan, PLAN, getPlusPlan } from './plans';
 import { c } from 'ttag';
+import useApi from '../api/useApi';
+import useNotifications from '../notifications/useNotifications';
+import useModals from '../modals/useModals';
+import useConfig from '../config/useConfig';
+import useApiResult from '../../hooks/useApiResult';
+import usePlans from '../../hooks/usePlans';
+import useVPNCountries from '../../hooks/useVPNCountries';
 
 const getSignupAvailability = (isDirectSignupEnabled, allowedMethods = []) => {
     const email = allowedMethods.includes(TOKEN_TYPES.EMAIL);
@@ -82,16 +80,16 @@ const useSignup = (onLogin, { coupon, invite, availablePlans } = {}, initialMode
     });
 
     const getPlanByName = (planName, cycle = model.cycle) =>
-        getVPNPlan(planName, cycle, plansWithCoupons || [], countries);
+        getPlan(CLIENT_TYPE, planName, cycle, plansWithCoupons || [], countries);
 
     // Until we can query plans+coupons at once, we need to check each plan individually
     useEffect(() => {
         const applyCoupon = async () => {
-            const vpnPlans = plans.filter(
+            const selectablePlans = plans.filter(
                 ({ Name, Type }) => Type === PLAN_TYPES.PLAN && availablePlans.includes(Name)
             );
             const plansWithCoupons = await Promise.all(
-                vpnPlans.map(async (plan) => {
+                selectablePlans.map(async (plan) => {
                     const {
                         AmountDue,
                         CouponDiscount,

--- a/containers/signup/useSignup.js
+++ b/containers/signup/useSignup.js
@@ -1,0 +1,257 @@
+import { useState, useEffect } from 'react';
+import { handlePaymentToken } from 'react-components/containers/payments/paymentTokenHelper';
+import { srpVerify, srpAuth } from 'proton-shared/lib/srp';
+import {
+    useApi,
+    usePlans,
+    useConfig,
+    useApiResult,
+    useModals,
+    useVPNCountries,
+    useNotifications
+} from 'react-components';
+import { queryCreateUser, queryDirectSignupStatus } from 'proton-shared/lib/api/user';
+import { auth, setCookies } from 'proton-shared/lib/api/auth';
+import { subscribe, setPaymentMethod, verifyPayment, checkSubscription } from 'proton-shared/lib/api/payments';
+import { mergeHeaders } from 'proton-shared/lib/fetch/helpers';
+import { getAuthHeaders } from 'proton-shared/lib/api';
+import { getRandomString } from 'proton-shared/lib/helpers/string';
+import {
+    DEFAULT_CURRENCY,
+    CYCLE,
+    PLAN_TYPES,
+    TOKEN_TYPES,
+    CURRENCIES,
+    PAYMENT_METHOD_TYPES
+} from 'proton-shared/lib/constants';
+import { getVPNPlan, PLAN, getPlusPlan } from './plans';
+import { c } from 'ttag';
+
+const getSignupAvailability = (isDirectSignupEnabled, allowedMethods = []) => {
+    const email = allowedMethods.includes(TOKEN_TYPES.EMAIL);
+    const sms = allowedMethods.includes(TOKEN_TYPES.SMS);
+    const paid = allowedMethods.includes(TOKEN_TYPES.PAYMENT);
+    const free = email || sms;
+
+    return {
+        allowedMethods,
+        inviteOnly: !isDirectSignupEnabled || (!free && !paid),
+        email,
+        free,
+        sms,
+        paid
+    };
+};
+
+const withAuthHeaders = (UID, AccessToken, config) => mergeHeaders(config, getAuthHeaders(UID, AccessToken));
+
+/**
+ * @param {Function} onLogin - callback after login that is done after registration
+ * @param {{
+ *  coupon: { plan, code, cycle },
+ *  invite: String
+ *  availablePlans: string[]
+ * }} config -  coupon/invite is ignored if method is not allowed
+ * @param {Object} initialModel - initially set values
+ */
+const useSignup = (onLogin, { coupon, invite, availablePlans } = {}, initialModel = {}) => {
+    const api = useApi();
+    const { createNotification } = useNotifications();
+    const { createModal } = useModals();
+    const { CLIENT_TYPE } = useConfig();
+    const { result } = useApiResult(() => queryDirectSignupStatus(CLIENT_TYPE), []);
+    const [plans] = usePlans();
+    const [plansWithCoupons, setPlansWithCoupons] = useState();
+    const [countries, countriesLoading] = useVPNCountries();
+    const [appliedCoupon, setAppliedCoupon] = useState();
+    const [appliedInvite, setAppliedInvite] = useState();
+
+    const signupAvailability = result && getSignupAvailability(result.Direct, result.VerifyMethods);
+    const defaultCurrency = plans && plans[0] ? plans[0].Currency : DEFAULT_CURRENCY;
+    const defaultCycle = coupon ? coupon.cycle : CYCLE.YEARLY;
+    const defaultPlan = coupon ? coupon.plan : getPlusPlan(CLIENT_TYPE);
+    const isLoading = !plansWithCoupons || !signupAvailability || countriesLoading;
+
+    const [model, setModel] = useState({
+        planName: Object.values(PLAN).includes(initialModel.planName) ? initialModel.planName : defaultPlan,
+        cycle: Object.values(CYCLE).includes(initialModel.cycle) ? initialModel.cycle : defaultCycle,
+        currency: CURRENCIES.includes(initialModel.currency) ? initialModel.currency : defaultCurrency,
+        email: initialModel.email || '',
+        username: initialModel.username || '',
+        password: initialModel.password || ''
+    });
+
+    const getPlanByName = (planName, cycle = model.cycle) =>
+        getVPNPlan(planName, cycle, plansWithCoupons || [], countries);
+
+    // Until we can query plans+coupons at once, we need to check each plan individually
+    useEffect(() => {
+        const applyCoupon = async () => {
+            const vpnPlans = plans.filter(
+                ({ Name, Type }) => Type === PLAN_TYPES.PLAN && availablePlans.includes(Name)
+            );
+            const plansWithCoupons = await Promise.all(
+                vpnPlans.map(async (plan) => {
+                    const {
+                        AmountDue,
+                        CouponDiscount,
+                        Coupon: { Description }
+                    } = await api(
+                        checkSubscription({
+                            CouponCode: coupon.code,
+                            Currency: model.currency,
+                            Cycle: model.cycle,
+                            PlanIDs: { [plan.ID]: 1 }
+                        })
+                    );
+                    return {
+                        ...plan,
+                        AmountDue,
+                        CouponDiscount,
+                        CouponDescription: Description
+                    };
+                })
+            );
+            setAppliedCoupon(coupon);
+            setPlansWithCoupons(plansWithCoupons);
+        };
+
+        if (!plans || !result) {
+            return;
+        }
+
+        if (coupon && !result.VerifyMethods.includes(TOKEN_TYPES.COUPON)) {
+            createNotification({ type: 'error', text: c('Notification').t`Coupons are temporarily disabled` });
+        }
+
+        if (coupon) {
+            applyCoupon();
+        } else {
+            setPlansWithCoupons(plans);
+        }
+    }, [availablePlans, result, plans, coupon, model.cycle, model.currency]);
+
+    useEffect(() => {
+        if (!invite || !signupAvailability) {
+            return;
+        }
+
+        if (!signupAvailability.allowedMethods.includes(TOKEN_TYPES.INVITE)) {
+            createNotification({ type: 'error', text: c('Notification').t`Invites are temporarily disabled` });
+        } else {
+            setAppliedInvite(invite);
+        }
+    }, [invite, signupAvailability]);
+
+    /**
+     * Makes payment, verifies it and saves payment details for signup
+     * @param {*=} paymentParameters payment parameters from usePayment
+     * @returns {Promise<{ VerifyCode, Payment }>} - paymentDetails
+     */
+    const makePayment = async (model, paymentParameters) => {
+        const selectedPlan = getPlanByName(model.planName, model.cycle);
+        const amount = selectedPlan.price.total;
+
+        if (amount > 0) {
+            const { Payment } = await handlePaymentToken({
+                params: {
+                    Amount: selectedPlan.price.total,
+                    Currency: model.currency,
+                    ...paymentParameters
+                },
+                api,
+                createModal
+            });
+
+            const { VerifyCode } = await api(
+                verifyPayment({
+                    Amount: amount,
+                    Currency: model.currency,
+                    Payment
+                })
+            );
+
+            return { VerifyCode, Payment };
+        }
+
+        return null;
+    };
+
+    const getToken = ({ coupon, invite, verificationToken, paymentDetails }) => {
+        if (invite) {
+            return { Token: `${invite.selector}:${invite.token}`, TokenType: TOKEN_TYPES.INVITE };
+        } else if (coupon) {
+            return { Token: coupon.code, TokenType: TOKEN_TYPES.COUPON };
+        } else if (paymentDetails) {
+            return { Token: paymentDetails.VerifyCode, TokenType: TOKEN_TYPES.PAYMENT };
+        }
+        return verificationToken;
+    };
+
+    const signup = async (model, signupToken) => {
+        const { Token, TokenType } = getToken(signupToken);
+        const { planName, password, email, username, currency, cycle } = model;
+        const selectedPlan = getPlanByName(planName, cycle);
+
+        await srpVerify({
+            api,
+            credentials: { password },
+            config: queryCreateUser({
+                Token,
+                TokenType,
+                Type: CLIENT_TYPE,
+                Email: email,
+                Username: username
+            })
+        });
+
+        const { UID, EventID, AccessToken, RefreshToken } = await srpAuth({
+            api,
+            credentials: { username, password },
+            config: auth({ Username: username })
+        });
+
+        // Add subscription
+        // Amount = 0 means - paid before subscription
+        if (planName !== PLAN.FREE) {
+            const subscription = {
+                PlanIDs: {
+                    [selectedPlan.id]: 1
+                },
+                Amount: 0,
+                Currency: currency,
+                Cycle: cycle,
+                CouponCode: signupToken.coupon ? Token : undefined
+            };
+            await api(withAuthHeaders(UID, AccessToken, subscribe(subscription)));
+        }
+
+        // Add payment method
+        if (
+            signupToken.paymentDetails &&
+            [PAYMENT_METHOD_TYPES.CARD, PAYMENT_METHOD_TYPES.PAYPAL].includes(signupToken.paymentMethodType)
+        ) {
+            await api(withAuthHeaders(UID, AccessToken, setPaymentMethod(signupToken.paymentDetails.Payment)));
+        }
+
+        // set cookies after login
+        await api(setCookies({ UID, AccessToken, RefreshToken, State: getRandomString(24) }));
+        onLogin({ UID, EventID });
+    };
+
+    return {
+        model,
+        isLoading,
+        getPlanByName,
+        selectedPlan: getPlanByName(model.planName),
+        signupAvailability,
+        appliedCoupon,
+        appliedInvite,
+
+        makePayment,
+        setModel,
+        signup
+    };
+};
+
+export default useSignup;

--- a/index.ts
+++ b/index.ts
@@ -350,6 +350,7 @@ export { useMainArea, MainAreaContext } from './hooks/useMainArea';
 export { default as useVPNCountries } from './hooks/useVPNCountries';
 export { default as useMessageCounts } from './hooks/useMessageCounts';
 export { default as useConversationCounts } from './hooks/useConversationCounts';
+export { default as SignupContainer } from './containers/signup/SignupContainer';
 
 export { default as ErrorBoundary } from './containers/app/ErrorBoundary';
 export { default as ProtonApp } from './containers/app/ProtonApp';


### PR DESCRIPTION
Works in mail/vpn, but there is some missing stuff until it's done:

- [ ] Mail plans features/icons/descriptions texts
- [ ] Dynamic login modal texts (when registering with protonmail/vpn account)
- [ ] Dynamic links (header, routes)
- [ ] Dynamic header (show mail logo)
- [ ] Plans table improvements (expanded, no plan selection)