### PR TITLE
Modify Searchbox so that it can be cleared from the outside

### DIFF
--- a/containers/search/Searchbox.js
+++ b/containers/search/Searchbox.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { c } from 'ttag';
 import PropTypes from 'prop-types';
 import { SearchInput, Icon } from 'react-components';
@@ -17,6 +17,11 @@ const Searchbox = ({ className = '', advanced, placeholder = '', value = '', onS
         updateSearch(newSearch);
         onChange && onChange(newSearch);
     };
+
+    useEffect(() => {
+        // needed in case the search is cleared
+        updateSearch(value);
+    }, [value === '']);
 
     return (
         <form


### PR DESCRIPTION
The input displayed in the Searchbox sometimes needs to be modified by external components (like in case of having to clear it). The simplest solution is to use a `useEffect` hook. Although it's ugly, notice that we are already using a similar structure in the `SearchInput` component