### PR TITLE
Fix - recovery email modal width

### DIFF
--- a/containers/notification/EmailModal.js
+++ b/containers/notification/EmailModal.js
@@ -68,7 +68,6 @@ const EmailModal = ({ email, hasReset, hasNotify, onClose, ...rest }) => {
             onClose={onClose}
             onSubmit={() => withLoading(handleSubmit())}
             title={c('Title').t`Update recovery/notification email`}
-            small
             {...rest}
         >
             <Row>


### PR DESCRIPTION
- used standard modal (not `mini` one)

![image](https://user-images.githubusercontent.com/2578321/67017636-57615e80-f0fa-11e9-94e9-ec540e5d13b2.png)
