### PR TITLE
Modify useActiveBreakpoints hook

### DIFF
--- a/components/sidebar/MobileNavServices.js
+++ b/components/sidebar/MobileNavServices.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useActiveBreakpoint } from 'react-components';
-import { isMobile } from 'proton-shared/lib/helpers/responsive';
 
 const MobileNavServices = ({ children }) => {
-    const breakpoint = useActiveBreakpoint();
+    const { isMobile } = useActiveBreakpoint();
 
-    if (!isMobile(breakpoint)) {
+    if (!isMobile) {
         return null;
     }
 

--- a/hooks/useActiveBreakpoint.js
+++ b/hooks/useActiveBreakpoint.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { debounce } from 'proton-shared/lib/helpers/function';
 
 const getBreakpoint = () => {
@@ -23,7 +23,12 @@ const useActiveBreakpoint = () => {
         };
     }, []);
 
-    return breakpoint;
+    return useMemo(() => ({
+        breakpoint,
+        isDesktop: breakpoint === 'desktop',
+        isTablet: breakpoint === 'tablet',
+        isMobile: breakpoint === 'mobile'
+    }));
 };
 
 export default useActiveBreakpoint;

--- a/hooks/useActiveBreakpoint.js
+++ b/hooks/useActiveBreakpoint.js
@@ -23,12 +23,15 @@ const useActiveBreakpoint = () => {
         };
     }, []);
 
-    return useMemo(() => ({
-        breakpoint,
-        isDesktop: breakpoint === 'desktop',
-        isTablet: breakpoint === 'tablet',
-        isMobile: breakpoint === 'mobile'
-    }));
+    return useMemo(
+        () => ({
+            breakpoint,
+            isDesktop: breakpoint === 'desktop',
+            isTablet: breakpoint === 'tablet',
+            isMobile: breakpoint === 'mobile'
+        }),
+        [breakpoint]
+    );
 };
 
 export default useActiveBreakpoint;


### PR DESCRIPTION
It's convenient to have it return Booleans `isMobile`, `isTablet` and `isDesktop` apart from the breakpoint itself