### PR TITLE
Changes to Identity Section of settings

### DIFF
--- a/containers/addresses/EditAddressModal.js
+++ b/containers/addresses/EditAddressModal.js
@@ -56,7 +56,6 @@ const EditAddressModal = ({ onClose, address, ...rest }) => {
                         value={model.displayName}
                         placeholder={c('Placeholder').t`Choose display name`}
                         onChange={handleDisplayName}
-                        required
                     />
                 </Field>
             </Row>

--- a/containers/addresses/IdentitySection.js
+++ b/containers/addresses/IdentitySection.js
@@ -77,8 +77,8 @@ const IdentitySection = () => {
                     <span className="mr0-5">{c('Label').t`Display name`}</span>
                     <Info url="https://protonmail.com/support/knowledge-base/display-name-and-signature/" />
                 </Label>
-                <Field>
-                    <div className="bordered-container pl1 pr1 pt0-5 pb0-5 ellipsis" title={address.DisplayName}>
+                <Field className="bordered-container">
+                    <div className="pl1 pr1 pt0-5 pb0-5 ellipsis" title={address.DisplayName}>
                         {address.DisplayName}
                     </div>
                 </Field>
@@ -88,10 +88,10 @@ const IdentitySection = () => {
             </Row>
             <Row>
                 <Label>{c('Label').t`Signature`}</Label>
-                <Field>
+                <Field className="bordered-container">
                     {address.Signature ? (
                         <div
-                            className="bordered-container break pl1 pr1 pt0-5 pb0-5"
+                            className="break pl1 pr1 pt0-5 pb0-5"
                             dangerouslySetInnerHTML={{ __html: address.Signature }}
                         />
                     ) : (


### PR DESCRIPTION
According to https://github.com/ProtonMail/proton-mail-settings/issues/176, we should allow an empty display name (consistent with the message displayed in the alert), and keep the size of the bordered container in the case of empty display name.

Closes https://github.com/ProtonMail/proton-mail-settings/issues/176