### PR TITLE
Fix warning in DropdownButton

### DIFF
--- a/components/dropdown/DropdownButton.js
+++ b/components/dropdown/DropdownButton.js
@@ -10,6 +10,8 @@ const DropdownButton = ({
     isOpen,
     children,
     caretClassName,
+    disabled,
+    loading,
     ...rest
 }) => {
     return (
@@ -18,6 +20,7 @@ const DropdownButton = ({
             type="button"
             className={classnames(['flex-item-noshrink', className])}
             aria-expanded={isOpen}
+            disabled={disabled || loading}
             {...rest}
         >
             <span className="mauto">
@@ -34,7 +37,9 @@ DropdownButton.propTypes = {
     hasCaret: PropTypes.bool,
     isOpen: PropTypes.bool,
     children: PropTypes.node,
-    className: PropTypes.string
+    className: PropTypes.string,
+    disabled: PropTypes.bool,
+    loading: PropTypes.bool
 };
 
 export default DropdownButton;

--- a/components/dropdown/DropdownButton.js
+++ b/components/dropdown/DropdownButton.js
@@ -10,8 +10,8 @@ const DropdownButton = ({
     isOpen,
     children,
     caretClassName,
-    disabled,
-    loading,
+    disabled = false,
+    loading = false,
     ...rest
 }) => {
     return (

--- a/components/dropdown/DropdownButton.js
+++ b/components/dropdown/DropdownButton.js
@@ -20,7 +20,8 @@ const DropdownButton = ({
             type="button"
             className={classnames(['flex-item-noshrink', className])}
             aria-expanded={isOpen}
-            disabled={disabled || loading}
+            aria-busy={loading}
+            disabled={loading ? true : disabled}
             {...rest}
         >
             <span className="mauto">


### PR DESCRIPTION
Sometimes a warning was being thrown in the console because the prop `loading` was passed to `<button>` throught the `DropdownButton` component.