### PR TITLE
Change wildcard toggle condition and text

### DIFF
--- a/containers/search/SearchSection.js
+++ b/containers/search/SearchSection.js
@@ -30,10 +30,10 @@ const SearchSection = () => {
                 <Field>
                     <Toggle
                         loading={loading}
-                        checked={!!AutoWildcardSearch}
+                        checked={!AutoWildcardSearch}
                         id="exactMatchToggle"
                         onChange={({ target: { checked } }) => {
-                            withLoading(api(updateAutoWildcardSearch(+checked)).then(call));
+                            withLoading(api(updateAutoWildcardSearch(+!checked)).then(call));
                         }}
                     />
                 </Field>


### PR DESCRIPTION
The new design require to have the text "Require exact match" for the toggle in `Settings > General > Search` instead of the v3 "Do not require exact match". We simply need to use the opposite values in this toggle. The corresponding PR fix in `mail` is awaiting review

Closes https://github.com/ProtonMail/proton-mail-settings/issues/191