### PR TITLE
updated classes to fix "Not set" padding

### DIFF
--- a/containers/addresses/IdentitySection.js
+++ b/containers/addresses/IdentitySection.js
@@ -95,7 +95,7 @@ const IdentitySection = () => {
                             dangerouslySetInnerHTML={{ __html: address.Signature }}
                         />
                     ) : (
-                        <div className="pt0-5 pl1 pr1 pt0-5 pb0-5 ">{c('Info').t`Not set`}</div>
+                        <div className="pl1 pr1 pt0-5 pb0-5">{c('Info').t`Not set`}</div>
                     )}
                 </Field>
                 <span className="ml1">

--- a/containers/addresses/IdentitySection.js
+++ b/containers/addresses/IdentitySection.js
@@ -95,7 +95,7 @@ const IdentitySection = () => {
                             dangerouslySetInnerHTML={{ __html: address.Signature }}
                         />
                     ) : (
-                        <div className="pt0-5">{c('Info').t`Not set`}</div>
+                        <div className="pt0-5 pl1 pr1 pt0-5 pb0-5 ">{c('Info').t`Not set`}</div>
                     )}
                 </Field>
                 <span className="ml1">


### PR DESCRIPTION
Fixes ProtonMail/proton-mail-settings#194
I added classes that were present in previous fields styled in a similar way.