### PR TITLE
Show fingerprints in title and add a copy button

### DIFF
--- a/containers/keys/KeysTable.js
+++ b/containers/keys/KeysTable.js
@@ -33,7 +33,7 @@ const KeysTable = ({ keys = [], onAction }) => {
                             key={ID}
                             cells={[
                                 <div key={1} className="flex flex-row flex-nowrap flex-items-center">
-                                    <Copy value={fingerprint} />
+                                    <Copy value={fingerprint} className="pm-button--small" />
                                     <code className="ml1 mw100 inbl ellipsis" title={fingerprint}>
                                         {fingerprint}
                                     </code>

--- a/containers/keys/KeysTable.js
+++ b/containers/keys/KeysTable.js
@@ -5,6 +5,7 @@ import { Table, TableCell, TableRow, TableBody } from 'react-components';
 
 import KeysActions from './KeysActions';
 import KeysStatus from './KeysStatus';
+import { Copy } from '../../components/button';
 
 const KeysTable = ({ keys = [], onAction }) => {
     const headerCells = [
@@ -31,9 +32,12 @@ const KeysTable = ({ keys = [], onAction }) => {
                         <TableRow
                             key={ID}
                             cells={[
-                                <code key={1} className="mw100 inbl ellipsis">
-                                    {fingerprint}
-                                </code>,
+                                <div key={1} className="flex flex-row flex-nowrap flex-items-center">
+                                    <Copy value={fingerprint} />
+                                    <code className="ml1 mw100 inbl ellipsis" title={fingerprint}>
+                                        {fingerprint}
+                                    </code>
+                                </div>,
                                 algorithm,
                                 <KeysStatus key={2} {...status} />,
                                 <KeysActions


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/202

Tooltip is not good in this case because it doesn't allow to select the fingerprint. In addition, the tooltip default size is not large enough to show the fingerprint.

So I propose a native HTML title and a copy button.

<img width="754" alt="Capture d’écran 2019-10-28 à 17 54 28" src="https://user-images.githubusercontent.com/475895/67699927-42fc4c00-f9ad-11e9-97e2-f118110e8d72.png">
