### PR TITLE
No need to have multiple member to add a new address

### DIFF
--- a/containers/addresses/AddressesSection.js
+++ b/containers/addresses/AddressesSection.js
@@ -9,7 +9,7 @@ const AddressesSection = () => {
     const [user] = useUser();
     const [organization, loadingOrganization] = useOrganization();
 
-    const { MaxMembers, UsedAddresses, MaxAddresses } = organization || {};
+    const { UsedAddresses, MaxAddresses } = organization || {};
 
     if (loadingOrganization) {
         return <Loader />;
@@ -18,7 +18,7 @@ const AddressesSection = () => {
     return (
         <>
             <SubTitle>{c('Title').t`Addresses`}</SubTitle>
-            {MaxMembers > 1 && user.isAdmin ? (
+            {user.isAdmin ? (
                 <AddressesWithMembers user={user} organization={organization} />
             ) : (
                 <AddressesWithUser user={user} />


### PR DESCRIPTION
To add a new address, you need to be a paid user to create `protonmail.com`, `protonmail.ch`, `pm.me` or custom domain addresses; and this can be done only on the main account.

Fix https://github.com/ProtonMail/proton-mail-settings/issues/205

