### PR TITLE
Make `guest` a reserved word that can't be used for OpenVPN credentials.

### DIFF
--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -25,6 +25,13 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
     const handleChangePassword = ({ target }) => setCredentials({ ...credentials, password: target.value });
 
     const handleSubmit = async () => {
+        const RESERVED_WORDS = ['guest'];
+        if (RESERVED_WORDS.includes(credentials.username)) {
+            createNotification({
+                text: c('Error').t`'${credentials.username}' is a reserved word. Please set another username.`
+            });
+            return;
+        }
         await api(updateVPNName(credentials.username));
         await api(updateVPNPassword(credentials.password));
         await fetchUserVPN();

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -25,8 +25,8 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
     const handleChangePassword = ({ target }) => setCredentials({ ...credentials, password: target.value });
 
     const handleSubmit = async () => {
-        const RESERVED_WORDS = ['guest'];
-        if (RESERVED_WORDS.includes(credentials.username.toLowerCase())) {
+        const RESERVED_USERNAMES = ['guest'];
+        if (RESERVED_USERNAMES.includes(credentials.username.toLowerCase())) {
             createNotification({
                 text: c('Error').t`'${credentials.username}' is a reserved word. Please set another username.`
             });

--- a/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
+++ b/containers/vpn/OpenVPNAccountSection/OpenVPNCredentialsModal.js
@@ -26,7 +26,7 @@ const OpenVPNCredentialsModal = ({ username = '', password = '', fetchUserVPN, .
 
     const handleSubmit = async () => {
         const RESERVED_WORDS = ['guest'];
-        if (RESERVED_WORDS.includes(credentials.username)) {
+        if (RESERVED_WORDS.includes(credentials.username.toLowerCase())) {
             createNotification({
                 text: c('Error').t`'${credentials.username}' is a reserved word. Please set another username.`
             });


### PR DESCRIPTION
Fixes https://gitlab.protontech.ch/ProtonVPN/web/protonvpn-settings/issues/23
