### PR TITLE
Catch pm.me address creation to display proper error

### DIFF
--- a/containers/addresses/AddressModal.js
+++ b/containers/addresses/AddressModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { c } from 'ttag';
 import PropTypes from 'prop-types';
 import { createAddress } from 'proton-shared/lib/api/addresses';
+import { ADDRESS_TYPE } from 'proton-shared/lib/constants';
 import {
     FormModal,
     Alert,
@@ -13,7 +14,10 @@ import {
     useNotifications,
     useEventManager,
     useModals,
-    useApi
+    useApi,
+    useAddresses,
+    usePremiumDomains,
+    useUser
 } from 'react-components';
 
 import useAddressModal from './useAddressModal';
@@ -23,15 +27,27 @@ import CreateMissingKeysAddressModal from './CreateMissingKeysAddressModal';
 const AddressModal = ({ onClose, member, organizationKey, ...rest }) => {
     const { createModal } = useModals();
     const { call } = useEventManager();
+    const [user, loadingUser] = useUser();
+    const [addresses, loadingAddresses] = useAddresses();
+    const [premiumDomains, loadingPremiumDomains] = usePremiumDomains();
+    const [premiumDomain = ''] = premiumDomains || [];
     const api = useApi();
     const { model, update } = useAddressModal(member);
     const { createNotification } = useNotifications();
     const [loading, withLoading] = useLoading();
-
+    const hasPremium = addresses.some(({ Type }) => Type === ADDRESS_TYPE.TYPE_PREMIUM);
     const handleChange = (key) => ({ target }) => update(key, target.value);
 
     const handleSubmit = async () => {
         const { name: DisplayName, address: Local, domain: Domain } = model;
+
+        if (!hasPremium && `${user.Name}@${premiumDomain}`.toLowerCase() === `${Local}@${Domain}`.toLowerCase()) {
+            return createNotification({
+                text: c('Error')
+                    .t`${Local} is your username. To create ${Local}@${Domain}, please go to Settings > Identity > Short domain (pm.me)`,
+                type: 'error'
+            });
+        }
 
         const { Address } = await api(
             createAddress({
@@ -41,6 +57,7 @@ const AddressModal = ({ onClose, member, organizationKey, ...rest }) => {
                 DisplayName
             })
         );
+
         await call();
 
         onClose();
@@ -56,7 +73,7 @@ const AddressModal = ({ onClose, member, organizationKey, ...rest }) => {
             title={c('Title').t`Create address`}
             submit={c('Action').t`Save`}
             cancel={c('Action').t`Cancel`}
-            loading={loading}
+            loading={loading || loadingAddresses || loadingPremiumDomains || loadingUser}
             onSubmit={() => withLoading(handleSubmit())}
             onClose={onClose}
             {...rest}

--- a/hooks/usePremiumDomains.js
+++ b/hooks/usePremiumDomains.js
@@ -1,0 +1,15 @@
+import { queryPremiumDomains } from 'proton-shared/lib/api/domains';
+
+import useCachedModelResult from './useCachedModelResult';
+import useApi from '../containers/api/useApi';
+import useCache from '../containers/cache/useCache';
+
+const getPremiumDomains = (api) => api(queryPremiumDomains()).then(({ Domains = [] }) => Domains);
+
+const usePremiumDomains = () => {
+    const api = useApi();
+    const cache = useCache();
+    return useCachedModelResult(cache, 'premiumDomains', () => getPremiumDomains(api));
+};
+
+export default usePremiumDomains;

--- a/index.ts
+++ b/index.ts
@@ -334,6 +334,7 @@ export { default as useCachedModelResult } from './hooks/useCachedModelResult';
 export { default as usePromiseResult } from './hooks/usePromiseResult';
 export { default as useAddresses } from './hooks/useAddresses';
 export { default as useDomains } from './hooks/useDomains';
+export { default as usePremiumDomains } from './hooks/usePremiumDomains';
 export { default as useCalendars } from './hooks/useCalendars';
 export { default as useActiveBreakpoint } from './hooks/useActiveBreakpoint';
 export { default as useContacts } from './hooks/useContacts';


### PR DESCRIPTION
![Capture d’écran 2019-10-29 à 15 17 42](https://user-images.githubusercontent.com/1345786/67775779-b1014b80-fa5f-11e9-9a07-93cdb67c9f95.png)

- catch if new address is Name@pm.me
- add usePremiumDomains hook
- use usePremiumDomains hook in DomainsSelect

Fix https://github.com/ProtonMail/proton-mail-settings/issues/206