### PR TITLE
Fix SIEVE editor by delaying content

### DIFF
--- a/containers/filters/editor/Sieve.js
+++ b/containers/filters/editor/Sieve.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import codemirror from 'codemirror';
 import PropTypes from 'prop-types';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
@@ -39,6 +39,8 @@ codemirror.registerHelper(
 function FilterEditorSieve({ filter, onChangeBeforeLint = noop, onChange = noop }) {
     const api = useApi();
 
+    const [value, setValue] = useState(null);
+
     useEffect(() => {
         /*
             Cheat to avoid broken context with react lifecycle as we can't
@@ -50,6 +52,8 @@ function FilterEditorSieve({ filter, onChangeBeforeLint = noop, onChange = noop 
             onChange(!!list.length, text);
             return list;
         };
+
+        setTimeout(() => setValue(filter.Sieve), 300);
 
         return () => {
             delete codemirror._uglyGlobal;
@@ -63,7 +67,7 @@ function FilterEditorSieve({ filter, onChangeBeforeLint = noop, onChange = noop 
     return (
         <CodeMirror
             className="bordered-container"
-            value={filter.Sieve}
+            value={value}
             options={{
                 mode: 'sieve',
                 lineNumbers: true,


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/214

This is a tricky bug inside codemirror. The selection is done by measuring and simulating the code area.

Perhaps due to the modal appearance animation, the initial measures are corrupted. Any refresh after that fix the problem. Any edition of the code does too.

The problem was: when to trigger a render? I did not found any good events to connect to. I never recommand to use setTimeout but I did not found anything else here.

"Theoretically" the measure issue is due to CSS annimation so the time is not directly dependant on the user computer performance so it "should" be stable.

Edit: the exact timing is 200ms, I used 300 to be secure.