### PR TITLE
Fix filter name validation

### DIFF
--- a/containers/filters/editor/Name.js
+++ b/containers/filters/editor/Name.js
@@ -17,9 +17,10 @@ function NameEditor({ filter, onChange = noop, error = {} }) {
                     defaultValue={filter.Name}
                     onChange={handleChange}
                     placeholder={c('Placeholder').t`Name`}
-                    required
                 />
-                {error.isEmpty ? <ErrorZone id="filterNameError">{c('Error').t`Username required`}</ErrorZone> : null}
+                {error.isEmpty ? (
+                    <ErrorZone id="filterNameError">{c('Error').t`Filter name required`}</ErrorZone>
+                ) : null}
             </Field>
         </Row>
     );


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/182

There is an internal validation mechanism inside the `Input` component. I think this was not intended here as there is an other one in the component.

Also, the label was referring to a username which should be a bad copy paste, I replaced it by "filter name".