### PR TITLE
Fix click behaviour on the info bubble on Safari

### DIFF
--- a/components/link/Info.js
+++ b/components/link/Info.js
@@ -28,7 +28,8 @@ const Info = ({
         scrollContainerClass
     });
 
-    const handleClick = () => {
+    const handleClick = (event) => {
+        event.preventDefault();
         url && window.open(url);
     };
 


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/215

We've got an `button` (from Info) in a `label`. On Safari only, it appears that clicking the button trigger the label, then the input associated. Calling `event.preventDefault()` prevents it (Not `event.stopPropagation()`).