### PR TITLE
Handle empty signature to send real empty string

### DIFF
--- a/containers/addresses/EditAddressModal.js
+++ b/containers/addresses/EditAddressModal.js
@@ -15,9 +15,9 @@ import {
     useEventManager
 } from 'react-components';
 
-const RichTextEditorEmptyValue = '<div><br></div>';
+const EMPTY_VALUES = [/<div><br><\/div>/, /<div>\s*<\/div>/];
 
-const formatSignature = (value) => (value === RichTextEditorEmptyValue ? '' : value);
+const formatSignature = (value) => (EMPTY_VALUES.some((regex) => regex.test(value)) ? '' : value);
 
 const EditAddressModal = ({ onClose, address, ...rest }) => {
     const api = useApi();
@@ -31,10 +31,12 @@ const EditAddressModal = ({ onClose, address, ...rest }) => {
 
     const handleDisplayName = ({ target }) => updateModel({ ...model, displayName: target.value });
 
-    const handleSignature = (value) => updateModel({ ...model, signature: formatSignature(value) });
+    const handleSignature = (value) => updateModel({ ...model, signature: value });
 
     const handleSubmit = async () => {
-        await api(updateAddress(address.ID, { DisplayName: model.displayName, Signature: model.signature }));
+        await api(
+            updateAddress(address.ID, { DisplayName: model.displayName, Signature: formatSignature(model.signature) })
+        );
         await call();
         onClose();
         createNotification({ text: c('Success').t`Address updated` });

--- a/containers/addresses/EditAddressModal.js
+++ b/containers/addresses/EditAddressModal.js
@@ -15,6 +15,10 @@ import {
     useEventManager
 } from 'react-components';
 
+const RichTextEditorEmptyValue = '<div><br></div>';
+
+const formatSignature = (value) => (value === RichTextEditorEmptyValue ? '' : value);
+
 const EditAddressModal = ({ onClose, address, ...rest }) => {
     const api = useApi();
     const { call } = useEventManager();
@@ -27,7 +31,7 @@ const EditAddressModal = ({ onClose, address, ...rest }) => {
 
     const handleDisplayName = ({ target }) => updateModel({ ...model, displayName: target.value });
 
-    const handleSignature = (value) => updateModel({ ...model, signature: value });
+    const handleSignature = (value) => updateModel({ ...model, signature: formatSignature(value) });
 
     const handleSubmit = async () => {
         await api(updateAddress(address.ID, { DisplayName: model.displayName, Signature: model.signature }));


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/177

Intercept empty input from the reach text editor for the signatuer and replace it by a real empty string.