### PR TITLE
Fix missing error message in card expiration field

### DIFF
--- a/containers/payments/Card.js
+++ b/containers/payments/Card.js
@@ -45,6 +45,7 @@ const Card = ({ card, errors, onChange, loading = false }) => {
                             onChange('month', month);
                             onChange('year', year);
                         }}
+                        required
                     />
                 </div>
                 <div className="flex-autogrid-item">


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/161

Validation seems to work. Was just missing a required attribute to handle when the user never touched the field.