### PR TITLE
Fix settings dashboard anchor links

### DIFF
--- a/components/sidebar/SubSidebar.js
+++ b/components/sidebar/SubSidebar.js
@@ -1,17 +1,9 @@
 import React from 'react';
 import { c } from 'ttag';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 const SubSidebar = ({ list = [], children, activeSection }) => {
-    const handleClick = (event) => {
-        const el = document.querySelector(`#${event.currentTarget.dataset.targetId}`);
-        // If the element was found, no need to set the hash since the intersection observer will do it
-        if (el) {
-            event.preventDefault();
-            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-    };
-
     return (
         <div className="subnav notablet nomobile bg-global-light noprint">
             <div className="subnav-inner">
@@ -21,14 +13,14 @@ const SubSidebar = ({ list = [], children, activeSection }) => {
                         const isCurrent = activeSection === id;
                         return (
                             <li key={id} className="mb0-5">
-                                <a
+                                <Link
                                     className="subnav-link"
                                     data-target-id={id}
-                                    onClick={handleClick}
+                                    to={{ hash: id }}
                                     aria-current={isCurrent}
                                 >
                                     {text}
-                                </a>
+                                </Link>
                             </li>
                         );
                     })}

--- a/containers/overview/IndexSection.js
+++ b/containers/overview/IndexSection.js
@@ -5,7 +5,7 @@ import { classnames } from '../../helpers/component';
 
 import Sections from './Sections';
 
-const IndexSection = ({ pages, history }) => {
+const IndexSection = ({ pages }) => {
     const permissions = usePermissions();
     return (
         <div className="settings-grid-container">
@@ -18,7 +18,7 @@ const IndexSection = ({ pages, history }) => {
                         <h2 className="h6 mb0-5">
                             <strong>{text}</strong>
                         </h2>
-                        {Sections({ route, sections, text, permissions, pagePermissions, history })}
+                        {Sections({ route, sections, text, permissions, pagePermissions })}
                     </div>
                 );
             })}
@@ -27,8 +27,7 @@ const IndexSection = ({ pages, history }) => {
 };
 
 IndexSection.propTypes = {
-    pages: PropTypes.array,
-    history: PropTypes.object.isRequired
+    pages: PropTypes.array
 };
 
 export default IndexSection;

--- a/containers/overview/IndexSection.js
+++ b/containers/overview/IndexSection.js
@@ -5,7 +5,7 @@ import { classnames } from '../../helpers/component';
 
 import Sections from './Sections';
 
-const IndexSection = ({ pages }) => {
+const IndexSection = ({ pages, history }) => {
     const permissions = usePermissions();
     return (
         <div className="settings-grid-container">
@@ -18,7 +18,7 @@ const IndexSection = ({ pages }) => {
                         <h2 className="h6 mb0-5">
                             <strong>{text}</strong>
                         </h2>
-                        {Sections({ route, sections, text, permissions, pagePermissions })}
+                        {Sections({ route, sections, text, permissions, pagePermissions, history })}
                     </div>
                 );
             })}
@@ -27,7 +27,8 @@ const IndexSection = ({ pages }) => {
 };
 
 IndexSection.propTypes = {
-    pages: PropTypes.array
+    pages: PropTypes.array,
+    history: PropTypes.object.isRequired
 };
 
 export default IndexSection;

--- a/containers/overview/LinkItem.js
+++ b/containers/overview/LinkItem.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 import { Tooltip, Icon } from 'react-components';
 import { c } from 'ttag';
+
+const href = (route) => `${route.pathname}#${route.hash}`;
 
 const LinkItem = ({ route, text, permission, history }) => {
     const handleClick = async (event) => {
         event.preventDefault();
 
-        history.push(route.pathname);
+        history.push(href(route));
 
         // Let the router do the navigation
         await null;
@@ -20,7 +21,7 @@ const LinkItem = ({ route, text, permission, history }) => {
     };
 
     return (
-        <a onClick={handleClick} href={`${route.pathname}#${route.hash}`}>
+        <a onClick={handleClick} href={href(route)}>
             <span className="mr0-5">{text}</span>
             {permission ? null : (
                 <Tooltip title={c('Tag').t`Premium feature`}>
@@ -35,7 +36,7 @@ LinkItem.propTypes = {
     route: PropTypes.object,
     permission: PropTypes.bool,
     text: PropTypes.string,
-    history: PropTypes.object
+    history: PropTypes.object.isRequired
 };
 
-export default withRouter(LinkItem);
+export default LinkItem;

--- a/containers/overview/LinkItem.js
+++ b/containers/overview/LinkItem.js
@@ -1,26 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import { Tooltip, Icon } from 'react-components';
 import { c } from 'ttag';
 
-const LinkItem = ({ route, text, permission }) => {
+const LinkItem = ({ route, text, permission, history }) => {
+    const handleClick = async (event) => {
+        event.preventDefault();
+
+        history.push(route.pathname);
+
+        // Let the router do the navigation
+        await null;
+
+        const el = document.querySelector(`#${route.hash}`);
+        if (el) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    };
+
     return (
-        <Link to={route}>
+        <a onClick={handleClick} href={`${route.pathname}#${route.hash}`}>
             <span className="mr0-5">{text}</span>
             {permission ? null : (
                 <Tooltip title={c('Tag').t`Premium feature`}>
                     <Icon name="starfull" fill="attention" />
                 </Tooltip>
             )}
-        </Link>
+        </a>
     );
 };
 
 LinkItem.propTypes = {
-    route: PropTypes.string,
+    route: PropTypes.object,
     permission: PropTypes.bool,
-    text: PropTypes.string
+    text: PropTypes.string,
+    history: PropTypes.object
 };
 
-export default LinkItem;
+export default withRouter(LinkItem);

--- a/containers/overview/LinkItem.js
+++ b/containers/overview/LinkItem.js
@@ -1,42 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { Tooltip, Icon } from 'react-components';
 import { c } from 'ttag';
 
-const href = (route) => `${route.pathname}#${route.hash}`;
-
-const LinkItem = ({ route, text, permission, history }) => {
-    const handleClick = async (event) => {
-        event.preventDefault();
-
-        history.push(href(route));
-
-        // Let the router do the navigation
-        await null;
-
-        const el = document.querySelector(`#${route.hash}`);
-        if (el) {
-            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-    };
-
+const LinkItem = ({ route, text, permission }) => {
     return (
-        <a onClick={handleClick} href={href(route)}>
+        <Link to={route}>
             <span className="mr0-5">{text}</span>
             {permission ? null : (
                 <Tooltip title={c('Tag').t`Premium feature`}>
                     <Icon name="starfull" fill="attention" />
                 </Tooltip>
             )}
-        </a>
+        </Link>
     );
 };
 
 LinkItem.propTypes = {
     route: PropTypes.object,
     permission: PropTypes.bool,
-    text: PropTypes.string,
-    history: PropTypes.object.isRequired
+    text: PropTypes.string
 };
 
 export default LinkItem;

--- a/containers/overview/Sections.js
+++ b/containers/overview/Sections.js
@@ -4,7 +4,7 @@ import { hasPermission } from 'proton-shared/lib/helpers/permissions';
 
 import LinkItem from './LinkItem';
 
-const Sections = ({ route, sections = [], text, permissions = [], pagePermissions }) => {
+const Sections = ({ route, sections = [], text, permissions = [], pagePermissions, history }) => {
     return (
         <ul className="unstyled mt0-5">
             {sections.length ? (
@@ -22,6 +22,7 @@ const Sections = ({ route, sections = [], text, permissions = [], pagePermission
                                     route={route}
                                     text={text}
                                     permission={hasPermission(permissions, pagePermissions, sectionPermissions)}
+                                    history={history}
                                 />
                             </li>
                         );
@@ -32,6 +33,7 @@ const Sections = ({ route, sections = [], text, permissions = [], pagePermission
                         route={{ pathname: route }}
                         text={text}
                         permission={hasPermission(permissions, pagePermissions)}
+                        history={history}
                     />
                 </li>
             )}
@@ -44,7 +46,8 @@ Sections.propTypes = {
     sections: PropTypes.array,
     text: PropTypes.string,
     permissions: PropTypes.array,
-    pagePermissions: PropTypes.array
+    pagePermissions: PropTypes.array,
+    history: PropTypes.object.isRequired
 };
 
 export default Sections;

--- a/containers/overview/Sections.js
+++ b/containers/overview/Sections.js
@@ -11,7 +11,7 @@ const Sections = ({ route, sections = [], text, permissions = [], pagePermission
                 sections
                     .reduce((acc, { text, id, hide }) => {
                         if (!hide) {
-                            acc.push({ text, id, route: `${route}#${id}` });
+                            acc.push({ text, id, route: { pathname: route, hash: id } });
                         }
                         return acc;
                     }, [])
@@ -28,7 +28,11 @@ const Sections = ({ route, sections = [], text, permissions = [], pagePermission
                     })
             ) : (
                 <li>
-                    <LinkItem route={route} text={text} permission={hasPermission(permissions, pagePermissions)} />
+                    <LinkItem
+                        route={{ pathname: route }}
+                        text={text}
+                        permission={hasPermission(permissions, pagePermissions)}
+                    />
                 </li>
             )}
         </ul>

--- a/containers/overview/Sections.js
+++ b/containers/overview/Sections.js
@@ -4,7 +4,7 @@ import { hasPermission } from 'proton-shared/lib/helpers/permissions';
 
 import LinkItem from './LinkItem';
 
-const Sections = ({ route, sections = [], text, permissions = [], pagePermissions, history }) => {
+const Sections = ({ route, sections = [], text, permissions = [], pagePermissions }) => {
     return (
         <ul className="unstyled mt0-5">
             {sections.length ? (
@@ -22,7 +22,6 @@ const Sections = ({ route, sections = [], text, permissions = [], pagePermission
                                     route={route}
                                     text={text}
                                     permission={hasPermission(permissions, pagePermissions, sectionPermissions)}
-                                    history={history}
                                 />
                             </li>
                         );
@@ -33,7 +32,6 @@ const Sections = ({ route, sections = [], text, permissions = [], pagePermission
                         route={{ pathname: route }}
                         text={text}
                         permission={hasPermission(permissions, pagePermissions)}
-                        history={history}
                     />
                 </li>
             )}
@@ -46,8 +44,7 @@ Sections.propTypes = {
     sections: PropTypes.array,
     text: PropTypes.string,
     permissions: PropTypes.array,
-    pagePermissions: PropTypes.array,
-    history: PropTypes.object.isRequired
+    pagePermissions: PropTypes.array
 };
 
 export default Sections;


### PR DESCRIPTION
(Almost) Fix https://github.com/ProtonMail/proton-mail-settings/issues/159

The links in the dashboard was containing the hash but in a soft navigation like this, it doesn't work.

I chose to change the link to add a manual `scrollIntoView` after the navigation.

It works pretty well unless that the scroll command is ran just after the navigation and if the page has async content, it will scroll to the position the anchor was before the data are there.

But to be honest, I don't see how it is possible to wait until the page is ready. So at least, it's better as before.