### PR TITLE
Add calendar link in AppsSidebar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,9 @@
             }
         }
     },
+    "globals": {
+        "FEATURE_FLAGS": true
+    },
     "extends": ["plugin:@typescript-eslint/recommended", "eslint:recommended", "plugin:react/recommended"],
     "rules": {
         "@typescript-eslint/explicit-function-return-type": "off",

--- a/containers/app/AppsSidebar.js
+++ b/containers/app/AppsSidebar.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, useConfig, Tooltip } from 'react-components';
+import { Icon, useConfig, useUser, Tooltip } from 'react-components';
 import { APPS } from 'proton-shared/lib/constants';
 
-const { PROTONMAIL, PROTONCONTACTS, PROTONMAIL_SETTINGS } = APPS;
+const { PROTONMAIL, PROTONCONTACTS, PROTONMAIL_SETTINGS, PROTONCALENDAR } = APPS;
 
 const AppsSidebar = ({ items = [] }) => {
     const { APP_NAME } = useConfig();
+    const [{ isPaid }] = useUser();
+
     const apps = [
         { appNames: [PROTONMAIL, PROTONMAIL_SETTINGS], icon: 'protonmail', title: 'ProtonMail', link: '/inbox' },
+        isPaid && { appNames: [PROTONCALENDAR], icon: 'protoncalendar', title: 'ProtonCalendar', link: '/calendar' },
         { appNames: [PROTONCONTACTS], icon: 'protoncontacts', title: 'ProtonContacts', link: '/contacts' }
     ].filter(Boolean);
 

--- a/containers/app/AppsSidebar.js
+++ b/containers/app/AppsSidebar.js
@@ -11,7 +11,13 @@ const AppsSidebar = ({ items = [] }) => {
 
     const apps = [
         { appNames: [PROTONMAIL, PROTONMAIL_SETTINGS], icon: 'protonmail', title: 'ProtonMail', link: '/inbox' },
-        isPaid && { appNames: [PROTONCALENDAR], icon: 'protoncalendar', title: 'ProtonCalendar', link: '/calendar' },
+        FEATURE_FLAGS.includes('calendar') &&
+            isPaid && {
+                appNames: [PROTONCALENDAR],
+                icon: 'protoncalendar',
+                title: 'ProtonCalendar',
+                link: '/calendar'
+            },
         { appNames: [PROTONCONTACTS], icon: 'protoncontacts', title: 'ProtonContacts', link: '/contacts' }
     ].filter(Boolean);
 


### PR DESCRIPTION
Fix https://github.com/ProtonMail/react-components/issues/406

This PR concern only the desktop aside bar. Other PR will be linked for mobile sidebar and Angular sidebar.