### PR TITLE
Improve filter edition modal, add auto reply action

### DIFF
--- a/containers/filters/editor/Actions.js
+++ b/containers/filters/editor/Actions.js
@@ -5,6 +5,7 @@ import { Loader, Label, Field, Select, Row, useFormattedLabels, ErrorZone } from
 import { noop } from 'proton-shared/lib/helpers/function';
 
 import LabelActions from './LabelActions';
+import AutoReplyAction from './AutoReplyAction';
 
 function ActionsEditor({ filter, onChange = noop, errors = {} }) {
     const { Actions } = filter.Simple;
@@ -25,8 +26,16 @@ function ActionsEditor({ filter, onChange = noop, errors = {} }) {
             value: 'archive'
         },
         {
-            text: c('Filter Actions').t`Move to mailbox`,
+            text: c('Filter Actions').t`Move to inbox`,
             value: 'inbox'
+        },
+        {
+            text: c('Filter Actions').t`Move to spam`,
+            value: 'spam'
+        },
+        {
+            text: c('Filter Actions').t`Move to trash`,
+            value: 'trash'
         }
     ].concat(folders);
 
@@ -52,7 +61,8 @@ function ActionsEditor({ filter, onChange = noop, errors = {} }) {
             }
         }),
         moveTo: (value) => ({ FileInto: [value] }),
-        labels: (Labels) => ({ Labels })
+        labels: (Labels) => ({ Labels }),
+        autoReply: (Vacation) => ({ Vacation })
     };
 
     const handleChange = (mode) => {
@@ -92,42 +102,55 @@ function ActionsEditor({ filter, onChange = noop, errors = {} }) {
         onChange(ACTIONS.labels(labels));
     };
 
+    const handleOnChangeAutoReply = (autoReply) => {
+        onChange(ACTIONS.autoReply(autoReply));
+    };
+
     return (
-        <Row>
-            <Label htmlFor="actions">{c('New Label form').t`Actions`}</Label>
-            <Field>
-                <div className="mb1">
-                    {loading ? (
-                        <Loader />
-                    ) : (
-                        <LabelActions onChange={handleOnChangeLabel} labels={labels} selection={getSelectedLabels()} />
-                    )}
-                </div>
-                <div className="mb1">
-                    {loading ? (
-                        <Loader />
-                    ) : (
+        <>
+            <div className="flex flex-nowrap onmobile-flex-column">
+                <Label htmlFor="actions">{c('New Label form').t`Actions`}</Label>
+                <Field>
+                    <div className="mb1">
+                        {loading ? (
+                            <Loader />
+                        ) : (
+                            <LabelActions
+                                onChange={handleOnChangeLabel}
+                                labels={labels}
+                                selection={getSelectedLabels()}
+                            />
+                        )}
+                    </div>
+                    <div className="mb1">
+                        {loading ? (
+                            <Loader />
+                        ) : (
+                            <Select
+                                options={MOVE_TO}
+                                onChange={handleChange('moveTo')}
+                                className="mlauto"
+                                defaultValue={getDefaultValue('moveTo')}
+                            />
+                        )}
+                    </div>
+                    <div className="mb1">
                         <Select
-                            options={MOVE_TO}
-                            onChange={handleChange('moveTo')}
+                            options={MARK_AS}
+                            onChange={handleChange('markAs')}
                             className="mlauto"
-                            defaultValue={getDefaultValue('moveTo')}
+                            defaultValue={getDefaultValue('markAs')}
                         />
-                    )}
-                </div>
-                <div className="mb1">
-                    <Select
-                        options={MARK_AS}
-                        onChange={handleChange('markAs')}
-                        className="mlauto"
-                        defaultValue={getDefaultValue('markAs')}
-                    />
-                </div>
-                {errors.isValid === false ? (
+                    </div>
+                </Field>
+            </div>
+            <AutoReplyAction onChange={handleOnChangeAutoReply} defaultValue={Actions.Vacation} />
+            {errors.isValid === false ? (
+                <Row>
                     <ErrorZone id="ActionsError">{c('Error').t`A filter must have an action`}</ErrorZone>
-                ) : null}
-            </Field>
-        </Row>
+                </Row>
+            ) : null}
+        </>
     );
 }
 

--- a/containers/filters/editor/AutoReplyAction.js
+++ b/containers/filters/editor/AutoReplyAction.js
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { c } from 'ttag';
+import { Label, Field, Toggle, RichTextEditor, Row } from 'react-components';
+import { noop } from 'proton-shared/lib/helpers/function';
+
+function AutoReplyAction({ defaultValue = null, onChange = noop }) {
+    const [activated, setActivated] = useState(!!defaultValue);
+    const [content, setContent] = useState(defaultValue);
+
+    useEffect(() => {
+        onChange(activated ? content : null);
+    }, [activated, content]);
+
+    return (
+        <>
+            <Row>
+                <Label>{/* Dummy label to hold space */ ' '}</Label>
+                <Field>
+                    <Toggle
+                        className="mr1"
+                        checked={activated}
+                        id="sendAutoReplyToggle"
+                        onChange={() => setActivated(!activated)}
+                    />
+                    <Label htmlFor="sendAutoReplyToggle">
+                        <span className="mr0-5">{c('Label').t`Send auto reply`}</span>
+                    </Label>
+                </Field>
+            </Row>
+            {activated && (
+                <Row className="pb3">
+                    <RichTextEditor
+                        className="w100"
+                        placeholder={c('Placeholder').t`Auto reply content`}
+                        value={content}
+                        onChange={(content) => setContent(content)}
+                    />
+                </Row>
+            )}
+        </>
+    );
+}
+
+AutoReplyAction.propTypes = {
+    defaultValue: PropTypes.string,
+    onChange: PropTypes.func
+};
+
+export default AutoReplyAction;

--- a/containers/filters/editor/Conditions.js
+++ b/containers/filters/editor/Conditions.js
@@ -150,13 +150,15 @@ function ConditionsEditor({ filter, onChange = noop, errors = [] }) {
                                 />
                             </Field>
                         )}
-                        <div className="ml1">
-                            <ErrorButton
-                                title={c('Action').t`Remove condition`}
-                                icon="trash"
-                                onClick={handleRemoveCondition(index)}
-                            />
-                        </div>
+                        {model.Simple.Conditions.length > 1 && (
+                            <div className="ml1">
+                                <ErrorButton
+                                    title={c('Action').t`Remove condition`}
+                                    icon="trash"
+                                    onClick={handleRemoveCondition(index)}
+                                />
+                            </div>
+                        )}
                     </Row>
                 );
             })}


### PR DESCRIPTION
Partially fix https://github.com/ProtonMail/proton-mail-settings/issues/218

- Trash icon only shown for 2 or more conditions
- Add move to spam and trash
- Change message for `Move to inbox`
- Add auto reply action