### PR TITLE
Fix false positives on signature ending with empty lines

### DIFF
--- a/containers/addresses/EditAddressModal.js
+++ b/containers/addresses/EditAddressModal.js
@@ -15,7 +15,7 @@ import {
     useEventManager
 } from 'react-components';
 
-const EMPTY_VALUES = [/<div><br><\/div>/, /<div>\s*<\/div>/];
+const EMPTY_VALUES = [/^(<div><br><\/div>)+$/, /^(<div>\s*<\/div>)+$/];
 
 const formatSignature = (value) => (EMPTY_VALUES.some((regex) => regex.test(value)) ? '' : value);
 


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/228

Sorry, that was an error in my regex. Should be stronger now.