### PR TITLE
Remove debounce on sieve lint

### DIFF
--- a/containers/filters/editor/Sieve.js
+++ b/containers/filters/editor/Sieve.js
@@ -3,7 +3,7 @@ import codemirror from 'codemirror';
 import PropTypes from 'prop-types';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import { useApi } from 'react-components';
-import { noop, debounce } from 'proton-shared/lib/helpers/function';
+import { noop } from 'proton-shared/lib/helpers/function';
 import { normalize } from 'proton-shared/lib/filters/sieve';
 import { FILTER_VERSION } from 'proton-shared/lib/constants';
 import { checkSieveFilter } from 'proton-shared/lib/api/filters';
@@ -15,26 +15,25 @@ import 'codemirror/lib/codemirror.css';
 import 'codemirror/addon/lint/lint.css';
 
 const clean = normalize();
-codemirror.registerHelper(
-    'lint',
-    'sieve',
-    debounce((text) => {
-        if (text.trim() === '') {
-            const [line = ''] = text.split('\n');
-            return [
-                {
-                    message: 'A sieve script cannot be empty',
-                    severity: 'error',
-                    from: codemirror.Pos(0, 0),
-                    to: codemirror.Pos(0, line.length)
-                }
-            ];
-        }
 
-        const lint = codemirror._uglyGlobal;
-        return lint ? lint(clean(text)) : [];
-    }, 500)
-);
+const lint = (text) => {
+    if (text.trim() === '') {
+        const [line = ''] = text.split('\n');
+        return [
+            {
+                message: 'A sieve script cannot be empty',
+                severity: 'error',
+                from: codemirror.Pos(0, 0),
+                to: codemirror.Pos(0, line.length)
+            }
+        ];
+    }
+
+    const lint = codemirror._uglyGlobal;
+    return lint ? lint(clean(text)) : [];
+};
+
+codemirror.registerHelper('lint', 'sieve', lint);
 
 function FilterEditorSieve({ filter, onChangeBeforeLint = noop, onChange = noop }) {
     const api = useApi();


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/221

The PR is very simple yet I dug a bit. The problem is that we added a debounce on the lint event to save some hit to the API. But this debounce lose the return value of the lint function which codemirror use to display the eventual error.

I worked on a "promised based version of the debounce" to make it works preserving the result. But while debugging it, I discover that codemirror already has a debounce mechanism and even if there is a lot of calls, the additional debounce doesn't catch much calls (At most, one or two calls in a whole normal usage).

So clearly, this simplest solution is to remove it.

(In Angular, there is no additional debounce either)