### PR TITLE
Feat - better CSS import

### DIFF
--- a/styles/index.scss
+++ b/styles/index.scss
@@ -49,11 +49,5 @@ $path-images: '~design-system/assets/img/shared/';
 @import '~design-system/_sass/design-system-website/global-structure';
 @import '~design-system/_sass/design-system-website/inside-content';
 
-@import '~design-system/_sass/reusable-components/design-system-responsive';
-@import '~design-system/_sass/design-system-website/responsive';
-@import '~design-system/_sass/reusable-components/design-system-print';
-@import '~design-system/_sass/reusable-components/design-system-viewport-fix';
-@import '~design-system/_sass/reusable-components/design-system-reduced-motion';
-
 @import '~design-system/_sass/react-styles/pm-dropdown';
 @import '~design-system/_sass/react-styles/pm-tooltip';


### PR DESCRIPTION
DO NOT MERGE IT UNTIL ALL PROJECTS ARE OK !!!!!!

- [X] Calendar
- [X] Mail Angular
- [x] Mail Settings
- [x] Mail Contacts
- [x] VPN settings
- [ ] Admin ?


## Short description of what this resolves:

React component import has to be simplified, in order to allow creating project specific components and avoid using these fragments everywhere if they are not needed.

## Changes proposed in this pull request:

- removed some fragments
- moving these fragments to projects
