### PR TITLE
Fix - minicalendar icons color

### DIFF
--- a/components/miniCalendar/MiniCalendar.js
+++ b/components/miniCalendar/MiniCalendar.js
@@ -62,14 +62,14 @@ const MiniCalendar = ({
         setTemporaryDate();
     }, [selectedDate]);
 
-    const classWeekNumber = displayWeekNumbers ? 'mini-calendar-grid--displayWeekNumber' : '';
+    const classWeekNumber = displayWeekNumbers ? 'minicalendar-grid--displayWeekNumber' : '';
     const classDark = displayedOnDarkBackground ? 'minicalendar--onDarkBackground' : '';
 
     const preventLeaveFocus = (e) => e.preventDefault();
 
     return (
         <div
-            className={classnames(['mini-calendar', classDark])}
+            className={classnames(['minicalendar', classDark])}
             onMouseDown={preventLeaveFocus}
             aria-label={monthLabel}
         >
@@ -77,18 +77,18 @@ const MiniCalendar = ({
                 <span className="bold flex-item-fluid">{monthLabel}</span>
                 {hasCursors ? (
                     <>
-                        <button type="button" className="mr1" onClick={() => handleSwitchMonth(-1)}>
-                            <Icon name="caret" size={12} className="rotateZ-90 fill-white" />
+                        <button type="button" title={prevMonth} className="mr1" onClick={() => handleSwitchMonth(-1)}>
+                            <Icon name="caret" size={12} className="rotateZ-90 minicalendar-icon" />
                             <span className="sr-only">{prevMonth}</span>
                         </button>
-                        <button type="button" onClick={() => handleSwitchMonth(1)}>
-                            <Icon name="caret" size={12} className="rotateZ-270 fill-white" />
+                        <button type="button" title={nextMonth} onClick={() => handleSwitchMonth(1)}>
+                            <Icon name="caret" size={12} className="rotateZ-270 minicalendar-icon" />
                             <span className="sr-only">{nextMonth}</span>
                         </button>
                     </>
                 ) : null}
             </div>
-            <div className={classnames(['mini-calendar-grid', classWeekNumber])}>
+            <div className={classnames(['minicalendar-grid', classWeekNumber])}>
                 {displayWeekNumbers ? <WeekNumbers numberOfWeeks={numberOfWeeks} days={days} /> : null}
                 <div>
                     <WeekDays


### PR DESCRIPTION
## Short description of what this resolves:

![image](https://user-images.githubusercontent.com/2578321/68305912-cfdb8f80-00a8-11ea-98e0-1bee59e29a16.png)

(icon next and prev month are white on white...)

## Changes proposed in this pull request:

- fixed color in Design system
- bonus: harmonized classnames `minicalendar` and `mini-calendar` => `minicalendar`

## Snapshot

![image](https://user-images.githubusercontent.com/2578321/68305596-3e6c1d80-00a8-11ea-9bea-6da78153d4ad.png)
