### PR TITLE
Login copy changes for drive login

### DIFF
--- a/containers/heading/SupportDropdownButton.js
+++ b/containers/heading/SupportDropdownButton.js
@@ -6,7 +6,11 @@ import { c } from 'ttag';
 const SupportDropdownButton = ({ content = c('Header').t`Support`, className, isOpen, buttonRef, ...rest }) => {
     return (
         <button type="button" className={className} aria-expanded={isOpen} ref={buttonRef} {...rest}>
-            <Icon name="support1" className="flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert" />
+            <Icon
+                name="support1"
+                fill={null}
+                className="flex-item-noshrink fill-currentColor topnav-icon mr0-5 flex-item-centered-vert"
+            />
             <span className="navigation-title topnav-linkText mr0-5">{content}</span>
             <DropdownCaret isOpen={isOpen} className="expand-caret topnav-icon mtauto mbauto" />
         </button>

--- a/containers/login/SignInLayout.js
+++ b/containers/login/SignInLayout.js
@@ -7,15 +7,34 @@ import { CLIENT_TYPES } from 'proton-shared/lib/constants';
 
 import PublicHeader from './PublicHeader';
 
-const { VPN } = CLIENT_TYPES;
+const { VPN, MAIL, DRIVE } = CLIENT_TYPES;
 
 const SignInLayout = ({ children, title }) => {
     const { CLIENT_TYPE } = useConfig();
-    const isVPN = CLIENT_TYPE === VPN;
-    const staticURL = isVPN ? 'protonvpn.com' : 'protonmail.com';
+
+    const envSpecific = {
+        [MAIL]: {
+            title: 'ProtonMail',
+            staticURL: 'protonmail.com',
+            logo: <MailLogo className="fill-primary" />,
+            footerLinkText: 'ProtonMail.com'
+        },
+        [VPN]: {
+            title: 'ProtonVPN',
+            staticURL: 'protonvpn.com',
+            logo: <VpnLogo className="fill-primary" />,
+            footerLinkText: 'ProtonVPN.com'
+        },
+        [DRIVE]: {
+            title: 'ProtonDrive',
+            staticURL: 'protondrive.com',
+            logo: 'Drive Logo',
+            footerLinkText: 'ProtonDrive.com'
+        }
+    }[CLIENT_TYPE];
 
     useEffect(() => {
-        document.title = `${title} - ${isVPN ? 'ProtonVPN' : 'ProtonMail'}`;
+        document.title = `${title} - ${envSpecific.title}`;
     }, []);
 
     return (
@@ -25,17 +44,17 @@ const SignInLayout = ({ children, title }) => {
                     <>
                         <span className="opacity-50">{c('Label').t`Back to:`}</span>{' '}
                         <Href
-                            url={`https://${staticURL}`}
+                            url={`https://${envSpecific.staticURL}`}
                             className="inbl color-white nodecoration hover-same-color"
                             target="_self"
                         >
-                            {staticURL}
+                            {envSpecific.staticURL}
                         </Href>
                     </>
                 }
                 middle={
-                    <Href url={staticURL} target="_self">
-                        {isVPN ? <VpnLogo className="fill-primary" /> : <MailLogo className="fill-primary" />}
+                    <Href url={envSpecific.staticURL} target="_self">
+                        {envSpecific.logo}
                     </Href>
                 }
                 right={
@@ -60,7 +79,7 @@ const SignInLayout = ({ children, title }) => {
                     </p>
                 </div>
                 <footer className="opacity-50 mtauto flex-item-noshrink aligncenter pb1">
-                    <FooterDetails link={<a href={staticURL}>{isVPN ? 'ProtonVPN.com' : 'ProtonMail.com'}</a>} />
+                    <FooterDetails link={<a href={envSpecific.staticURL}>{envSpecific.footerLinkText}</a>} />
                 </footer>
             </div>
         </div>

--- a/containers/login/SignInLayout.js
+++ b/containers/login/SignInLayout.js
@@ -28,7 +28,7 @@ const SignInLayout = ({ children, title }) => {
         [DRIVE]: {
             title: 'ProtonDrive',
             staticURL: 'protondrive.com',
-            logo: 'Drive Logo',
+            logo: <MailLogo className="fill-primary" />,
             footerLinkText: 'ProtonDrive.com'
         }
     }[CLIENT_TYPE];


### PR DESCRIPTION
Needs: https://github.com/ProtonMail/proton-shared/pull/71 first

Login page for ProtonDrive, currently uses ProtonMail logo until it gets it's own. Also links are not decided yet, so just using some dummy links for now too.

## Short description of what this resolves:

https://proton.atlassian.net/browse/DRV-27

## Changes proposed in this pull request:

Just updates our signup component with drive related copy. Also fixes fill color for support icon on dropdown button.

## Snapshot

![image](https://user-images.githubusercontent.com/944727/68668353-a4492100-0550-11ea-9233-59811476eb52.png)
