### PR TITLE
Fix: Filter Action Label uses path instead of name

### DIFF
--- a/containers/filters/editor/Actions.js
+++ b/containers/filters/editor/Actions.js
@@ -83,7 +83,7 @@ function ActionsEditor({ filter, onChange = noop, errors = {} }) {
 
         if (mode === 'moveTo') {
             const MAP = labelModel.getLabelsMap();
-            const key = Actions.FileInto.find((name) => !MAP[name]);
+            const key = Actions.FileInto.find((path) => !MAP[path]);
             if (key) {
                 return key;
             }
@@ -93,7 +93,7 @@ function ActionsEditor({ filter, onChange = noop, errors = {} }) {
     const getSelectedLabels = () => {
         const MAP = labelModel.getLabelsMap();
         const { Labels = [], FileInto } = Actions;
-        const toLabel = (name) => MAP[name];
+        const toLabel = (path) => MAP[path];
         const list = FileInto.filter(toLabel);
         return [...new Set(Labels.concat(list))].map(toLabel);
     };

--- a/containers/filters/editor/LabelActions.js
+++ b/containers/filters/editor/LabelActions.js
@@ -14,7 +14,7 @@ function LabelActions({ selection = [], labels = [], onChange = noop }) {
         multiple: true,
         initialSelectedItems: selection,
         onChange(selection) {
-            onChange(selection.map(({ Name }) => Name));
+            onChange(selection.map(({ Path }) => Path));
         }
     });
 


### PR DESCRIPTION
## Short description of what this resolves:

When creating a filter, adding the action Label uses the `Name` instead of the `Path`.

## Changes proposed in this pull request:

- Label selection is now done using the Path as a key. 
- the labelsModel.mapLabels must use the Path as key as well. This is done in PR: https://github.com/ProtonMail/proton-shared/pull/73

Fixes https://github.com/ProtonMail/proton-mail-settings/issues/240

## Snapshot
