### PR TITLE
Fix last empty condition value issue and move action validation

### DIFF
--- a/containers/filters/editor/Actions.js
+++ b/containers/filters/editor/Actions.js
@@ -19,7 +19,8 @@ function ActionsEditor({ filter, onChange = noop, errors = {} }) {
 
     const MOVE_TO = [
         {
-            text: c('Filter Actions').t`Move to ...`
+            text: c('Filter Actions').t`Move to ...`,
+            value: ''
         },
         {
             text: c('Filter Actions').t`Move to archive`,
@@ -60,7 +61,7 @@ function ActionsEditor({ filter, onChange = noop, errors = {} }) {
                 Read: value === 'read'
             }
         }),
-        moveTo: (value) => ({ FileInto: [value] }),
+        moveTo: (value) => ({ FileInto: value === '' ? [] : [value] }),
         labels: (Labels) => ({ Labels }),
         autoReply: (Vacation) => ({ Vacation })
     };

--- a/containers/filters/editor/AddConditionValue.js
+++ b/containers/filters/editor/AddConditionValue.js
@@ -5,7 +5,7 @@ import { Input, Button } from 'react-components';
 import { noop } from 'proton-shared/lib/helpers/function';
 
 function AddCondtionValue({ value = '', onEdit = noop, onAdd = noop }) {
-    const handleAdd = () => onAdd('');
+    const handleAdd = () => onAdd(null);
 
     // keyDown as it won't trigger the submit event ;)
     const handleKeyDown = (e) => {
@@ -17,13 +17,13 @@ function AddCondtionValue({ value = '', onEdit = noop, onAdd = noop }) {
         handleAdd();
     };
 
-    const handleInput = ({ target }) => onEdit(target.value);
+    const handleInput = ({ target }) => onEdit(target.value === '' ? null : target.value);
 
     return (
         <div className="flex flex-nowrap">
             <Input
                 id="textOrPattern"
-                value={value}
+                value={value === null ? '' : value}
                 className="mr1"
                 onKeyDown={handleKeyDown}
                 onInput={handleInput}

--- a/containers/filters/editor/Preview.js
+++ b/containers/filters/editor/Preview.js
@@ -100,7 +100,7 @@ function PreviewFilter({ filter }) {
                                     {Type.label} {Comparator.label}
                                 </b>
                                 :{' '}
-                                {Values.map((val, i) => {
+                                {Values.filter((val) => val !== null).map((val, i) => {
                                     return (
                                         <span
                                             className="Preview-condition-value"


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/245

Replace the last condition value by a null value if empty.
But it need to be sanitize before sending to the API: https://github.com/ProtonMail/proton-shared/pull/79

Fix https://github.com/ProtonMail/proton-mail-settings/issues/241