### PR TITLE
Throw payment error for DuckDuckGo

### DIFF
--- a/components/alert/DuckDuckGoAlertError.js
+++ b/components/alert/DuckDuckGoAlertError.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { c } from 'ttag';
+
+import Alert from './Alert';
+
+const DuckDuckGoAlertError = () => (
+    <Alert type="error">{c('Error')
+        .t`The browser you are using does not allow the payment to be fully authorized. Please use a different browser or log in via a computer.`}</Alert>
+);
+
+export default DuckDuckGoAlertError;

--- a/containers/payments/PayPal.js
+++ b/containers/payments/PayPal.js
@@ -1,7 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import { Alert, Loader, SmallButton, Price, useApi, useLoading, PrimaryButton, LinkButton } from 'react-components';
+import {
+    Alert,
+    Loader,
+    SmallButton,
+    Price,
+    useApi,
+    useLoading,
+    PrimaryButton,
+    LinkButton,
+    DuckDuckGoAlertError
+} from 'react-components';
 import { MIN_PAYPAL_AMOUNT, MAX_PAYPAL_AMOUNT, PAYMENT_METHOD_TYPES } from 'proton-shared/lib/constants';
 import { createToken } from 'proton-shared/lib/api/payments';
 
@@ -99,10 +109,7 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     }
 
     if (isDuckDuckGo()) {
-        return (
-            <Alert type="error">{c('Error')
-                .t`The browser you are using does not allow the payment to be fully authorized. Please use a different browser or log in via a computer.`}</Alert>
-        );
+        return <DuckDuckGoAlertError />;
     }
 
     if (loadingToken) {

--- a/containers/payments/PayPal.js
+++ b/containers/payments/PayPal.js
@@ -101,7 +101,7 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     if (isDuckDuckGo()) {
         return (
             <Alert type="error">{c('Error')
-                .t`The browser you are using does not support this payment type. Please use a different browser or log in via a computer.`}</Alert>
+                .t`The browser you are using does not allow the payment to be fully authorized. Please use a different browser or log in via a computer.`}</Alert>
         );
     }
 

--- a/containers/payments/PayPal.js
+++ b/containers/payments/PayPal.js
@@ -6,6 +6,7 @@ import { MIN_PAYPAL_AMOUNT, MAX_PAYPAL_AMOUNT, PAYMENT_METHOD_TYPES } from 'prot
 import { createToken } from 'proton-shared/lib/api/payments';
 
 import { toParams, process } from './paymentTokenHelper';
+import { isDuckDuckGo } from 'proton-shared/lib/helpers/browser';
 
 const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
     const api = useApi();
@@ -94,6 +95,13 @@ const PayPal = ({ amount: Amount, currency: Currency, onPay, type }) => {
                     >{c('Action').t`Try again`}</SmallButton>
                 </div>
             </Alert>
+        );
+    }
+
+    if (isDuckDuckGo()) {
+        return (
+            <Alert type="error">{c('Error')
+                .t`The browser you are using does not support this payment type. Please use a different browser or log in via a computer.`}</Alert>
         );
     }
 

--- a/containers/payments/PaymentVerificationModal.js
+++ b/containers/payments/PaymentVerificationModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
     FormModal,
@@ -49,7 +49,7 @@ const PaymentVerificationModal = ({
             : c('Title').t`Payment verification in progress`,
         [STEPS.FAIL]: c('Title').t`3-D Secure verification failed`
     };
-    const [step, setStep] = useState(STEPS.REDIRECT);
+    const [step, setStep] = useState(() => (isDuckDuckGo() ? STEPS.DUCKDUCKGO : STEPS.REDIRECT));
     const [error, setError] = useState({});
     const api = useApi();
     const { createNotification } = useNotifications();
@@ -87,12 +87,6 @@ const PaymentVerificationModal = ({
             }
         }
     };
-
-    useEffect(() => {
-        if (isDuckDuckGo()) {
-            setStep(STEPS.DUCKDUCKGO);
-        }
-    }, []);
 
     return (
         <FormModal

--- a/containers/payments/PaymentVerificationModal.js
+++ b/containers/payments/PaymentVerificationModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
     FormModal,
@@ -8,16 +8,19 @@ import {
     ResetButton,
     useNotifications,
     useApi,
-    PrimaryButton
+    PrimaryButton,
+    DuckDuckGoAlertError
 } from 'react-components';
 import { c } from 'ttag';
 import errorSvg from 'design-system/assets/img/pm-images/error.svg';
 import { ADD_CARD_MODE, PAYMENT_METHOD_TYPES } from 'proton-shared/lib/constants';
+import { isDuckDuckGo } from 'proton-shared/lib/helpers/browser';
 
 import { toParams, process } from './paymentTokenHelper';
 import PaymentVerificationImage from './PaymentVerificationImage';
 
 const STEPS = {
+    DUCKDUCKGO: 'duckduckgo',
     REDIRECT: 'redirect',
     REDIRECTING: 'redirecting',
     REDIRECTED: 'redirected',
@@ -38,6 +41,7 @@ const PaymentVerificationModal = ({
 }) => {
     const isAddCard = mode === ADD_CARD_MODE;
     const TITLES = {
+        [STEPS.DUCKDUCKGO]: c('Title').c`Unsupported browser`,
         [STEPS.REDIRECT]: isAddCard ? c('Title').t`Card verification` : c('Title').t`Payment verification`,
         [STEPS.REDIRECTING]: c('Title').t`Processing...`,
         [STEPS.REDIRECTED]: isAddCard
@@ -83,6 +87,12 @@ const PaymentVerificationModal = ({
             }
         }
     };
+
+    useEffect(() => {
+        if (isDuckDuckGo()) {
+            setStep(STEPS.DUCKDUCKGO);
+        }
+    }, []);
 
     return (
         <FormModal
@@ -143,6 +153,12 @@ const PaymentVerificationModal = ({
                                     ? c('Info').t`Verification can take a few minutes.`
                                     : c('Info').t`Payment can take a few minutes to fully verify.`}
                             </Alert>
+                        </>
+                    ),
+                    [STEPS.DUCKDUCKGO]: (
+                        <>
+                            <DuckDuckGoAlertError />
+                            <Button onClick={handleCancel}>{c('Action').t`Close`}</Button>
                         </>
                     ),
                     [STEPS.FAIL]: (

--- a/containers/payments/PaymentVerificationModal.js
+++ b/containers/payments/PaymentVerificationModal.js
@@ -41,7 +41,7 @@ const PaymentVerificationModal = ({
 }) => {
     const isAddCard = mode === ADD_CARD_MODE;
     const TITLES = {
-        [STEPS.DUCKDUCKGO]: c('Title').c`Unsupported browser`,
+        [STEPS.DUCKDUCKGO]: c('Title').t`Unsupported browser`,
         [STEPS.REDIRECT]: isAddCard ? c('Title').t`Card verification` : c('Title').t`Payment verification`,
         [STEPS.REDIRECTING]: c('Title').t`Processing...`,
         [STEPS.REDIRECTED]: isAddCard

--- a/containers/payments/paymentTokenHelper.js
+++ b/containers/payments/paymentTokenHelper.js
@@ -5,7 +5,6 @@ import { wait } from 'proton-shared/lib/helpers/promise';
 import { c } from 'ttag';
 import { PaymentVerificationModal } from 'react-components';
 import { getHostname } from 'proton-shared/lib/helpers/url';
-import { isDuckDuckGo } from 'proton-shared/lib/helpers/browser';
 
 const {
     STATUS_PENDING,
@@ -179,13 +178,6 @@ export const handlePaymentToken = async ({ params, api, createModal, mode }) => 
 
     if (Status === STATUS_CHARGEABLE) {
         return toParams(params, Token, Type);
-    }
-
-    if (isDuckDuckGo()) {
-        throw new Error(
-            c('Error')
-                .t`The browser you are using does not allow the payment to be fully authorized. Please use a different browser or log in via a computer.`
-        );
     }
 
     return new Promise((resolve, reject) => {

--- a/containers/payments/paymentTokenHelper.js
+++ b/containers/payments/paymentTokenHelper.js
@@ -184,7 +184,7 @@ export const handlePaymentToken = async ({ params, api, createModal, mode }) => 
     if (isDuckDuckGo()) {
         throw new Error(
             c('Error')
-                .t`The browser you are using does not support 3D-Secure payments. Please use a different browser or log in via a computer.`
+                .t`The browser you are using does not support this payment type. Please use a different browser or log in via a computer.`
         );
     }
 

--- a/containers/payments/paymentTokenHelper.js
+++ b/containers/payments/paymentTokenHelper.js
@@ -5,6 +5,7 @@ import { wait } from 'proton-shared/lib/helpers/promise';
 import { c } from 'ttag';
 import { PaymentVerificationModal } from 'react-components';
 import { getHostname } from 'proton-shared/lib/helpers/url';
+import { isDuckDuckGo } from 'proton-shared/lib/helpers/browser';
 
 const {
     STATUS_PENDING,
@@ -178,6 +179,13 @@ export const handlePaymentToken = async ({ params, api, createModal, mode }) => 
 
     if (Status === STATUS_CHARGEABLE) {
         return toParams(params, Token, Type);
+    }
+
+    if (isDuckDuckGo()) {
+        throw new Error(
+            c('Error')
+                .t`The browser you are using does not support 3D-Secure payments. Please use a different browser or log in via a computer.`
+        );
     }
 
     return new Promise((resolve, reject) => {

--- a/containers/payments/paymentTokenHelper.js
+++ b/containers/payments/paymentTokenHelper.js
@@ -184,7 +184,7 @@ export const handlePaymentToken = async ({ params, api, createModal, mode }) => 
     if (isDuckDuckGo()) {
         throw new Error(
             c('Error')
-                .t`The browser you are using does not support this payment type. Please use a different browser or log in via a computer.`
+                .t`The browser you are using does not allow the payment to be fully authorized. Please use a different browser or log in via a computer.`
         );
     }
 

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ export { default as Select } from './components/select/Select';
 export { default as Breadcrumb } from './components/breadcrumb/Breadcrumb';
 export { default as Wizard } from './components/wizard/Wizard';
 export { default as Alert } from './components/alert/Alert';
+export { default as DuckDuckGoAlertError } from './components/alert/DuckDuckGoAlertError';
 export { default as Icon } from './components/icon/Icon';
 export { default as RoundedIcon } from './components/icon/RoundedIcon';
 export { default as Icons } from './components/icon/Icons';


### PR DESCRIPTION
DuckDuckGo mobile browser is not supporting [window.open](https://www.w3schools.com/jsref/met_win_open.asp) method required for our payment flow. So we have to handle this case properly for `card` and `paypal` payment methods.

- For PayPal we just display an error panel in the view.
- For card, we display the same error in the `PaymentVerificationModal` after getting the `Token` if the `Status` is not directly chargeable.

Manager: @jovanjovanovski 
Test server: https://vpnsettings.protonmail.blue (blue API)