### PR TITLE
Fix - bad alignment in report modal

### DIFF
--- a/containers/support/AttachScreenshot.js
+++ b/containers/support/AttachScreenshot.js
@@ -42,7 +42,7 @@ const AttachScreenshot = ({ id, onUpload, onReset }) => {
             <>
                 <div className="flex flex-nowrap flex-items-center">
                     <Icon name="insert-image" className="mr0-5" />
-                    <span className="mr1">{c('Info').t`Screenshot(s) attached`}</span>
+                    <span className="mr1 flex-item-fluid">{c('Info').t`Screenshot(s) attached`}</span>
                     <Button onClick={handleClick}>{c('Action').t`Clear`}</Button>
                 </div>
             </>
@@ -50,7 +50,7 @@ const AttachScreenshot = ({ id, onUpload, onReset }) => {
     }
 
     return (
-        <FileInput multiple accept="image/*" id={id} onChange={handleChange}>{c('Action')
+        <FileInput className="flex" multiple accept="image/*" id={id} onChange={handleChange}>{c('Action')
             .t`Add screenshot(s)`}</FileInput>
     );
 };


### PR DESCRIPTION
## Short description of what this resolves:

Vertical alignment was not correct
![image](https://user-images.githubusercontent.com/2578321/69719474-dfcb1a00-1110-11ea-86f6-5121281bb1bf.png)


## Changes proposed in this pull request:

- aligned buttons (add screenshot and once snapshot uploaded)

## Snapshots

![image](https://user-images.githubusercontent.com/2578321/69720138-3d139b00-1112-11ea-914a-15e6ed0ee8bb.png)
![image](https://user-images.githubusercontent.com/2578321/69720313-a2678c00-1112-11ea-86e1-d6ac9ee266ac.png)
