### PR TITLE
Add clear search buttons on search bars

### DIFF
--- a/containers/search/SearchDropdown.js
+++ b/containers/search/SearchDropdown.js
@@ -1,6 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { SearchInput, DropdownButton, Dropdown, Icon, usePopperAnchor, PrimaryButton } from 'react-components';
+import {
+    SearchInput,
+    DropdownButton,
+    Dropdown,
+    Icon,
+    usePopperAnchor,
+    PrimaryButton,
+    ResetButton
+} from 'react-components';
 import { c } from 'ttag';
 
 import { generateUID } from '../../helpers/component';
@@ -24,6 +32,13 @@ const SearchDropdown = ({
         close();
     };
 
+    const handleReset = (event) => {
+        event.preventDefault();
+        updateSearch('');
+        onSearch('');
+        close();
+    };
+
     return (
         <>
             <DropdownButton {...rest} buttonRef={anchorRef} isOpen={isOpen} onClick={toggle}>
@@ -40,8 +55,9 @@ const SearchDropdown = ({
                             placeholder={placeholder}
                         />
                     </div>
-                    <div>
-                        <PrimaryButton className="w100" type="submit">{c('Action').t`Search`}</PrimaryButton>
+                    <div className="flex flex-nowrap">
+                        <ResetButton className="w50" onClick={handleReset}>{c('Action').t`Clear`}</ResetButton>
+                        <PrimaryButton className="w50 ml1" type="submit">{c('Action').t`Search`}</PrimaryButton>
                     </div>
                 </form>
             </Dropdown>

--- a/containers/search/Searchbox.js
+++ b/containers/search/Searchbox.js
@@ -16,6 +16,12 @@ const Searchbox = ({ className = '', advanced, placeholder = '', value = '', onS
         onChange && onChange(newSearch);
     };
 
+    const handleClear = () => {
+        updateSearch('');
+        onChange && onChange('');
+        onSearch && onSearch('');
+    };
+
     useEffect(() => {
         // needed in case the search is cleared
         updateSearch(value);
@@ -41,6 +47,14 @@ const Searchbox = ({ className = '', advanced, placeholder = '', value = '', onS
                 <Icon name="search" className="fill-white mauto searchbox-search-button-icon" />
                 <span className="sr-only">{c('Action').t`Search`}</span>
             </button>
+            {// Clear button is hidden when using advanced mode because the buttons use the same spots
+            // If there is the need of having both, a positioning solution will have to be found
+            !advanced && search !== '' && (
+                <button type="button" className="searchbox-advanced-search-button flex" onClick={handleClear}>
+                    <Icon name="close" className="fill-white mauto searchbox-search-button-icon" />
+                    <span className="sr-only">{c('Action').t`Clear`}</span>
+                </button>
+            )}
             {advanced}
         </form>
     );


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-contacts/issues/275

Add clear buttons on both mobile and desktop search bars.

![Capture d’écran 2019-11-29 à 17 16 46](https://user-images.githubusercontent.com/475895/69881085-33359780-12cc-11ea-9bbc-b3c57b778ea2.png)
![Capture d’écran 2019-11-29 à 17 17 02](https://user-images.githubusercontent.com/475895/69881086-33ce2e00-12cc-11ea-9942-dccbcc798368.png)

On desktop, the cross is hidden when the search field is empty or if the advanced feature is used.