### PR TITLE
Fix - add custom scrollbar fragment

### DIFF
--- a/styles/index.scss
+++ b/styles/index.scss
@@ -40,6 +40,7 @@ $path-images: '~design-system/assets/img/shared/';
 @import '~design-system/_sass/pm-styles/pm-table-plans';
 @import '~design-system/_sass/pm-styles/pm-circlebar';
 @import '~design-system/_sass/pm-styles/pm-mini-calendar';
+@import '~design-system/_sass/pm-styles/pm-custom-scrollbar';
 
 @import '~design-system/_sass/pm-styles/pm-aside';
 @import '~design-system/_sass/pm-styles/pm-toolbar';


### PR DESCRIPTION
## Short description of what this resolves:

Add missing fragment for custom scrollbars (which will be used on several projects)

## Changes proposed in this pull request:

- Add missing fragment for custom scrollbars (!) (needed for Calendar)


## Snapshot

![image](https://user-images.githubusercontent.com/2578321/70058280-e6f59a80-15de-11ea-915a-1e5f23bd817c.png)

