### PR TITLE
Round payment amounts to 2 digits after the floating point

### DIFF
--- a/containers/payments/PaymentSelector.js
+++ b/containers/payments/PaymentSelector.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Input } from 'react-components';
 import { c } from 'ttag';
@@ -7,27 +7,45 @@ import CurrencySelector from './CurrencySelector';
 import AmountButton from './AmountButton';
 
 const PaymentSelector = ({ currency, amount, onChangeCurrency, onChangeAmount }) => {
-    const handleChange = ({ target }) => onChangeAmount(target.value * 100);
+    const [inputValue, setInputValue] = useState('');
+
+    const handleButton = (value) => {
+        setInputValue('');
+        onChangeAmount(value);
+    };
+    const handleChange = ({ target }) => {
+        setInputValue(target.value);
+        onChangeAmount(Math.floor(target.value * 100));
+    };
+    const handleBlur = () => {
+        setInputValue(amount / 100);
+    };
 
     return (
         <>
             <div className="flex-autogrid onmobile-flex-column">
                 <div className="flex-autogrid-item">
-                    <AmountButton className="w100" onSelect={onChangeAmount} value={500} amount={amount} />
+                    <AmountButton className="w100" onSelect={handleButton} value={500} amount={amount} />
                 </div>
                 <div className="flex-autogrid-item">
-                    <AmountButton className="w100" onSelect={onChangeAmount} value={1000} amount={amount} />
+                    <AmountButton className="w100" onSelect={handleButton} value={1000} amount={amount} />
                 </div>
                 <div className="flex-autogrid-item">
-                    <AmountButton className="w100" onSelect={onChangeAmount} value={5000} amount={amount} />
+                    <AmountButton className="w100" onSelect={handleButton} value={5000} amount={amount} />
                 </div>
                 <div className="flex-autogrid-item">
-                    <AmountButton className="w100" onSelect={onChangeAmount} value={10000} amount={amount} />
+                    <AmountButton className="w100" onSelect={handleButton} value={10000} amount={amount} />
                 </div>
             </div>
             <div className="flex-autogrid onmobile-flex-column">
                 <div className="flex-autogrid-item">
-                    <Input className="w100" onChange={handleChange} placeholder={c('Placeholder').t`Other`} />
+                    <Input
+                        className="w100"
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        value={inputValue}
+                        placeholder={c('Placeholder').t`Other`}
+                    />
                 </div>
                 <div className="flex-autogrid-item">
                     <CurrencySelector className="w100" currency={currency} onSelect={onChangeCurrency} />


### PR DESCRIPTION
Fix: https://github.com/ProtonMail/proton-mail-settings/issues/256

Round the amount entered in the `other` input field to 2 digits after the floating point.

I also override the amount value in the input field on blur unless the client was paying for an amount different than what it was on screen.

