### PR TITLE
Fix - support drop down icon color

### DIFF
--- a/containers/heading/SupportDropdownButton.js
+++ b/containers/heading/SupportDropdownButton.js
@@ -6,7 +6,10 @@ import { c } from 'ttag';
 const SupportDropdownButton = ({ content = c('Header').t`Support`, className, isOpen, buttonRef, ...rest }) => {
     return (
         <button type="button" className={className} aria-expanded={isOpen} ref={buttonRef} {...rest}>
-            <Icon name="support1" className="flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert" />
+            <Icon
+                name="support1"
+                className="flex-item-noshrink topnav-icon mr0-5 fill-currentColor flex-item-centered-vert"
+            />
             <span className="navigation-title topnav-linkText mr0-5">{content}</span>
             <DropdownCaret isOpen={isOpen} className="expand-caret topnav-icon mtauto mbauto" />
         </button>


### PR DESCRIPTION
## Short description of what this resolves:

Icon of support drop down was not visible. 
![image](https://user-images.githubusercontent.com/2578321/70145160-bf1a3b80-169f-11ea-95e1-c263e2a13541.png)


## Changes proposed in this pull request:

- added `fill-currentColor` class (the icon will be the same color as the text in the button)


## Snapshot

![image](https://user-images.githubusercontent.com/2578321/70145096-a0b44000-169f-11ea-9549-c48bf5c4bd42.png)

![image](https://user-images.githubusercontent.com/2578321/70145120-aad63e80-169f-11ea-883d-d0a07b6dd716.png)
