### PR TITLE
Do not show upgrade storage button when on visionary or lifetime plan

### DIFF
--- a/containers/sidebar/StorageSpaceStatus.js
+++ b/containers/sidebar/StorageSpaceStatus.js
@@ -5,28 +5,23 @@ import {
     CircularProgress,
     Dropdown,
     Icon,
+    Loader,
     generateUID,
     useUser,
     usePopperAnchor,
     useSubscription
 } from 'react-components';
 import humanSize from 'proton-shared/lib/helpers/humanSize';
-import { getPlanName, hasLifetime } from 'proton-shared/lib/helpers/subscription';
-import { PLANS } from 'proton-shared/lib/constants';
+import { hasVisionary, hasLifetime } from 'proton-shared/lib/helpers/subscription';
 
 import { classnames } from '../../helpers/component';
 
-const { VISIONARY } = PLANS;
-
 const StorageSpaceStatus = ({ upgradeButton }) => {
     const [{ MaxSpace, UsedSpace }] = useUser();
-    const [subscription = {}] = useSubscription();
+    const [subscription, loadingSubscription] = useSubscription();
     const [uid] = useState(generateUID('dropdown'));
     const { anchorRef, isOpen, toggle, close } = usePopperAnchor();
-    const planName = getPlanName(subscription);
-    const hasVisionaryPlan = planName === VISIONARY;
-    const hasLifetimePlan = hasLifetime(subscription);
-    const canUpgradeStorage = !hasVisionaryPlan && !hasLifetimePlan;
+    const canUpgradeStorage = !hasVisionary(subscription) && !hasLifetime(subscription);
 
     // round with 0.01 precision
     const usedPercent = Math.round((UsedSpace / MaxSpace) * 10000) / 100;
@@ -86,7 +81,7 @@ const StorageSpaceStatus = ({ upgradeButton }) => {
                                     {c('Info').t`Your storage space is shared across all Proton products.`}
                                 </span>
                             </div>
-                            {canUpgradeStorage ? upgradeButton : null}
+                            {loadingSubscription ? <Loader /> : canUpgradeStorage ? upgradeButton : null}
                         </div>
                     </div>
                 </div>
@@ -96,7 +91,7 @@ const StorageSpaceStatus = ({ upgradeButton }) => {
 };
 
 StorageSpaceStatus.propTypes = {
-    upgradeButton: PropTypes.node
+    upgradeButton: PropTypes.node.isRequired
 };
 
 export default StorageSpaceStatus;

--- a/containers/sidebar/StorageSpaceStatus.js
+++ b/containers/sidebar/StorageSpaceStatus.js
@@ -1,15 +1,32 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import { CircularProgress, Dropdown, Icon, generateUID, useUser, usePopperAnchor } from 'react-components';
+import {
+    CircularProgress,
+    Dropdown,
+    Icon,
+    generateUID,
+    useUser,
+    usePopperAnchor,
+    useSubscription
+} from 'react-components';
 import humanSize from 'proton-shared/lib/helpers/humanSize';
+import { getPlanName, hasLifetime } from 'proton-shared/lib/helpers/subscription';
+import { PLANS } from 'proton-shared/lib/constants';
 
 import { classnames } from '../../helpers/component';
 
-const StorageSpaceStatus = ({ children }) => {
+const { VISIONARY } = PLANS;
+
+const StorageSpaceStatus = ({ upgradeButton }) => {
     const [{ MaxSpace, UsedSpace }] = useUser();
+    const [subscription = {}] = useSubscription();
     const [uid] = useState(generateUID('dropdown'));
     const { anchorRef, isOpen, toggle, close } = usePopperAnchor();
+    const planName = getPlanName(subscription);
+    const hasVisionaryPlan = planName === VISIONARY;
+    const hasLifetimePlan = hasLifetime(subscription);
+    const canUpgradeStorage = !hasVisionaryPlan && !hasLifetimePlan;
 
     // round with 0.01 precision
     const usedPercent = Math.round((UsedSpace / MaxSpace) * 10000) / 100;
@@ -69,7 +86,7 @@ const StorageSpaceStatus = ({ children }) => {
                                     {c('Info').t`Your storage space is shared across all Proton products.`}
                                 </span>
                             </div>
-                            {children}
+                            {canUpgradeStorage ? upgradeButton : null}
                         </div>
                     </div>
                 </div>
@@ -79,7 +96,7 @@ const StorageSpaceStatus = ({ children }) => {
 };
 
 StorageSpaceStatus.propTypes = {
-    children: PropTypes.node
+    upgradeButton: PropTypes.node
 };
 
 export default StorageSpaceStatus;


### PR DESCRIPTION
Fixes https://github.com/ProtonMail/react-components/issues/459

