### PR TITLE
Fix - orderable table CSS fix for Dark mode

### DIFF
--- a/components/orderableTable/OrderableTable.scss
+++ b/components/orderableTable/OrderableTable.scss
@@ -1,11 +1,12 @@
+@import '~design-system/_sass/reusable-components/design-system-config';
 .orderableHelper {
     z-index: 666;
     display: flex;
     align-items: center;
-    color: black;
-    background: white;
-    border-top: 1px solid #dde6ec;
-    border-bottom: 1px solid #dde6ec;
+    color: var(--color-main-area, $pm-global-grey);
+    background: var(--bgcolor-main-area, $white);
+    border-top: 1px solid var(--bordercolor-input, $pm-global-border);
+    border-bottom: 1px solid var(--bordercolor-input, $pm-global-border);
 
     /**
      * We replace td with custom class here because we don't have direct access to it.
@@ -17,7 +18,7 @@
         height: 100%;
         &:first-child {
             flex-grow: 0;
-            flex-basis: 35px;
+            flex-basis: 3.5rem;
         }
     }
 }


### PR DESCRIPTION
## Short description of what this resolves:

Orderable table had a white background in darkmode ^^

## Changes proposed in this pull request:

- fixed styles for orderable table - no update on default theme (as the CSS variable is not set, the color will use the fallback one)

## Snapshot

![image](https://user-images.githubusercontent.com/2578321/70548085-44a35d00-1b72-11ea-955c-c1ec58ea6110.png)

