### PR TITLE
Fix - made billing footer dark mode friendly

### DIFF
--- a/containers/payments/BillingSection.js
+++ b/containers/payments/BillingSection.js
@@ -303,7 +303,7 @@ const BillingSection = ({ permission }) => {
                         </div>
                     </div>
                 </div>
-                <div className="bg-global-light pt1 pl1 pr1">
+                <div className="bg-global-highlight pt1 pl1 pr1">
                     <div className="flex-autogrid onmobile-flex-column w100 mb1">
                         <div className="flex-autogrid-item">{c('Label').t`Billing cycle`}</div>
                         <div className="flex-autogrid-item">


### PR DESCRIPTION
## Short description of what this resolves:

- billing footer was a bit too visible in Dark mode
![image](https://user-images.githubusercontent.com/2578321/70549638-d318de00-1b74-11ea-8d37-b55ba40b2d7c.png)


## Changes proposed in this pull request:

- used another bg helper class alias which is dark mode friendly: `bg-global-highlight` (added here https://github.com/ProtonMail/design-system/commit/901595fdd6bc8be8f0a0eb43766a9354fe6a8000 )

## Snapshot

![image](https://user-images.githubusercontent.com/2578321/70549491-977e1400-1b74-11ea-91d9-30e85baa1f36.png)
