### PR TITLE
Fix - related settings alignments/responsive

### DIFF
--- a/components/container/Information.js
+++ b/components/container/Information.js
@@ -4,11 +4,11 @@ import { Icon } from 'react-components';
 
 const Information = ({ icon = 'info', children }) => {
     return (
-        <div className="information-panel bordered-container relative">
-            <div className="information-panel-image flex bg-global-light">
+        <div className="information-panel bordered-container relative flex flex-column">
+            <div className="information-panel-image flex bg-global-highlight">
                 <Icon name={icon} className="mauto" />
             </div>
-            <div className="information-panel-content">{children}</div>
+            <div className="information-panel-content flex h100  flex-column">{children}</div>
         </div>
     );
 };

--- a/components/container/RelatedSettingsSection.js
+++ b/components/container/RelatedSettingsSection.js
@@ -12,13 +12,13 @@ const RelatedSettingsSection = ({ list = [{}] }) => {
     return (
         <>
             <SubTitle>{c('Title').t`Related settings`}</SubTitle>
-            <div className="flex flex-spacebetween">
+            <div className="flex flex-spacebetween ontablet-flex-column">
                 {list.map(({ icon, text, to, link }, index) => {
                     return (
-                        <div key={index.toString()} className="w45">
+                        <div key={index.toString()} className="w45 flex ontablet-mb1">
                             <Information icon={icon}>
                                 <Paragraph>{text}</Paragraph>
-                                <Paragraph className="aligncenter">
+                                <Paragraph className="aligncenter mtauto">
                                     <Link className="pm-button pm-button--primary" to={to}>
                                         {link}
                                     </Link>


### PR DESCRIPTION
## Short description of what this resolves:

Alignments of related settings blocks were not good.

## Changes proposed in this pull request:

- bottom-aligned button
- made blocks same height
- enhanced responsive
- fixed a point for dark mode

## Snapshot

Desktop :
![image](https://user-images.githubusercontent.com/2578321/70554132-de700780-1b7c-11ea-8c5d-fb8427c3dcd6.png)
Tablets/mobile:
![image](https://user-images.githubusercontent.com/2578321/70554171-f21b6e00-1b7c-11ea-8254-0b1153e7e8f7.png)
