### PR TITLE
Return stream response as ReadableStream instead of Reader

### DIFF
--- a/containers/api/ApiProvider.js
+++ b/containers/api/ApiProvider.js
@@ -94,7 +94,7 @@ const ApiProvider = ({ config, onLogout, children, UID }) => {
                 if (serverTime) {
                     updateServerTime(serverTime);
                 }
-                return output === 'stream' ? response.body.getReader() : response[output]();
+                return output === 'stream' ? response.body : response[output]();
             });
         };
     }


### PR DESCRIPTION
Sometimes it's useful to have the whole stream instead of only reader (e.g. required for streaming decryption)