### PR TITLE
Read i18n config from the config

### DIFF
--- a/containers/general/LanguageSection.js
+++ b/containers/general/LanguageSection.js
@@ -8,6 +8,7 @@ import {
     Label,
     Select,
     useApi,
+    useConfig,
     useLoading,
     useNotifications,
     useForceRefresh,
@@ -18,33 +19,11 @@ import { updateLocale } from 'proton-shared/lib/api/settings';
 import loadLocale from 'proton-shared/lib/i18n/loadLocale';
 import { getBrowserLocale, getClosestMatches } from 'proton-shared/lib/i18n/helper';
 
-/* eslint-disable @typescript-eslint/camelcase */
-const LOCALES = {
-    cs_CZ: 'Čeština',
-    de_DE: 'Deutsch',
-    en_US: 'English',
-    es_ES: 'Español',
-    ca_ES: 'Español - català',
-    fr_FR: 'Français',
-    hr_HR: 'Hrvatski',
-    it_IT: 'Italiano',
-    ja_JP: '日本語',
-    nl_NL: 'Nederlands',
-    pl_PL: 'Polski',
-    pt_BR: 'Português, brasileiro',
-    ru_RU: 'Pусский',
-    ro_RO: 'Română',
-    tr_TR: 'Türkçe',
-    uk_UA: 'Українська',
-    zh_CN: '简体中文',
-    zh_TW: '繁體中'
-};
-/* eslint-enable @typescript-eslint/camelcase */
-
 const LanguageSection = ({ locales = {} }) => {
-    const [{ Locale }] = useUserSettings();
     const api = useApi();
     const { call } = useEventManager();
+    const { LOCALES = {} } = useConfig();
+    const [{ Locale }] = useUserSettings();
     const { createNotification } = useNotifications();
     const [loading, withLoading] = useLoading();
     const forceRefresh = useForceRefresh();


### PR DESCRIPTION
## Short description of what this resolves:

Remove hardcoded values from the code. Now it's going to be /project with a config file generated via the CI

ex:
```json
{
  "de_DE": "Deutsch",
  "en_US": "English",
  "es_ES": "Español",
  "es_MX": "Español Mexico",
  "fr_FR": "Français",
  "id_ID": "bahasa Indonesia",
  "it_IT": "Italiano",
  "nl_NL": "Dutch",
  "pl_PL": "Polski",
  "pt_BR": "Português do Brasil",
  "pt_PT": "Português",
  "ru_RU": "Pусский"
}
``` 

## Changes proposed in this pull request:

- Load locale configuration via the config

Post merge, you will need to run `$ npm update proton-pack` as we need the v3.0.4 to get this config.