### PR TITLE
Fix - mini-calendar display in responsive

### DIFF
--- a/components/miniCalendar/MonthDays.js
+++ b/components/miniCalendar/MonthDays.js
@@ -95,7 +95,7 @@ const MonthDays = ({
 
     return (
         <ul
-            className="unstyled aligncenter minicalendar-days"
+            className="unstyled m0 aligncenter minicalendar-days"
             style={style}
             onClick={handleClick}
             onMouseDown={onSelectDateRange ? handleMouseDown : null}

--- a/components/miniCalendar/MonthDays.js
+++ b/components/miniCalendar/MonthDays.js
@@ -94,8 +94,8 @@ const MonthDays = ({
     const [rangeStart, rangeEnd] = temporaryDateRange || dateRange || [];
 
     return (
-        <div
-            className="aligncenter minicalendar-days"
+        <ul
+            className="unstyled aligncenter minicalendar-days"
             style={style}
             onClick={handleClick}
             onMouseDown={onSelectDateRange ? handleMouseDown : null}
@@ -133,22 +133,23 @@ const MonthDays = ({
                 ]);
 
                 return (
-                    <button
-                        disabled={isOutsideMinMax}
-                        aria-label={formatDay(dayDate)}
-                        aria-current={isCurrent ? 'date' : undefined}
-                        aria-pressed={isPressed ? true : undefined}
-                        key={dayDate.toString()}
-                        className={className}
-                        data-i={i}
-                        data-current-day={dayDate.getDate()}
-                    >
-                        <span className="minicalendar-day-inner">{dayDate.getDate()}</span>
-                        {hasMarker ? <span className="minicalendar-day--marker" /> : null}
-                    </button>
+                    <li key={dayDate.toString()}>
+                        <button
+                            disabled={isOutsideMinMax}
+                            aria-label={formatDay(dayDate)}
+                            aria-current={isCurrent ? 'date' : undefined}
+                            aria-pressed={isPressed ? true : undefined}
+                            className={className}
+                            data-i={i}
+                            data-current-day={dayDate.getDate()}
+                        >
+                            <span className="minicalendar-day-inner">{dayDate.getDate()}</span>
+                            {hasMarker ? <span className="minicalendar-day--marker" /> : null}
+                        </button>
+                    </li>
                 );
             })}
-        </div>
+        </ul>
     );
 };
 


### PR DESCRIPTION
## Short description of what this resolves:

Display of mini-calendar in responsive was bugged (not a circle for current day, etc.)
![image](https://user-images.githubusercontent.com/2578321/70984196-57f68100-20ba-11ea-9c55-59b5645a7dcb.png)


## Changes proposed in this pull request:

- wrapped buttons into a `li`s (which will be better vocalized btw), so `li` will be the grid cells
- moved `key` to `li`


## Snapshot

![image](https://user-images.githubusercontent.com/2578321/70984062-18c83000-20ba-11ea-992e-52cc583fbe69.png)

