### PR TITLE
Proposal for centering months in mini-calendar

### DIFF
--- a/components/miniCalendar/helper.js
+++ b/components/miniCalendar/helper.js
@@ -1,4 +1,4 @@
-import { addWeeks, subWeeks, eachDayOfInterval, endOfWeek, startOfMonth, startOfWeek, getDay } from 'date-fns';
+import { addWeeks, subWeeks, eachDayOfInterval, endOfWeek, startOfMonth, startOfWeek, isSameDay } from 'date-fns';
 
 /**
  * Get all days to display in the mini calendar for a given date.
@@ -12,7 +12,7 @@ export const getDaysInMonth = (currentDate, { weekStartsOn, weeks }) => {
     const startOfWeekDate = startOfWeek(startOfMonthDate, { weekStartsOn });
     // in case of displaying 6 weeks for a month starting on weekStartsOn day,
     // display last week of previous month so that trailing days are displayed both at the beginning and the end
-    const adjust = getDay(startOfMonthDate) === weekStartsOn && weeks === 5;
+    const adjust = isSameDay(startOfMonthDate, startOfWeekDate) && weeks === 5;
 
     const start = adjust ? subWeeks(startOfWeekDate, 1) : startOfWeekDate;
     const end = endOfWeek(addWeeks(start, weeks), { weekStartsOn });

--- a/components/miniCalendar/helper.js
+++ b/components/miniCalendar/helper.js
@@ -1,4 +1,4 @@
-import { addWeeks, eachDayOfInterval, endOfWeek, startOfMonth, startOfWeek } from 'date-fns';
+import { addWeeks, subWeeks, eachDayOfInterval, endOfWeek, startOfMonth, startOfWeek, getDay } from 'date-fns';
 
 /**
  * Get all days to display in the mini calendar for a given date.
@@ -8,7 +8,14 @@ import { addWeeks, eachDayOfInterval, endOfWeek, startOfMonth, startOfWeek } fro
  * @returns {Array<Date>}
  */
 export const getDaysInMonth = (currentDate, { weekStartsOn, weeks }) => {
-    const start = startOfWeek(startOfMonth(currentDate), { weekStartsOn });
+    const startOfMonthDate = startOfMonth(currentDate);
+    const startOfWeekDate = startOfWeek(startOfMonthDate, { weekStartsOn });
+    // in case of displaying 6 weeks for a month starting on weekStartsOn day,
+    // display last week of previous month so that trailing days are displayed both at the beginning and the end
+    const adjust = getDay(startOfMonthDate) === weekStartsOn && weeks === 5;
+
+    const start = adjust ? subWeeks(startOfWeekDate, 1) : startOfWeekDate;
     const end = endOfWeek(addWeeks(start, weeks), { weekStartsOn });
+
     return eachDayOfInterval({ start, end });
 };


### PR DESCRIPTION
When displaying 6 weeks in the mini-calendar, center the month in it