### PR TITLE
Fix - a11y improvement for global search

### DIFF
--- a/containers/search/Searchbox.js
+++ b/containers/search/Searchbox.js
@@ -29,6 +29,7 @@ const Searchbox = ({ className = '', advanced, placeholder = '', value = '', onS
 
     return (
         <form
+            role="search"
             name="searchbox"
             className={classnames(['searchbox-container relative flex-item-centered-vert', className])}
             onSubmit={handleSubmit}


### PR DESCRIPTION
## Short description of what this resolves:

While re-reading some BP in accessibility in french, I just realized that we did not follow this BP => identify the global search using `role="search"`, see https://www.accede-web.com/en/guidelines/html-css-javascript/1-structure/1-2-role-search/ 

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role

## Changes proposed in this pull request:

- Just added `role="search"` on global search.

a11y FTW!
![meow_ok](https://user-images.githubusercontent.com/2578321/72329590-4f8f6700-36b5-11ea-8e78-783e8b8569f6.gif)
