### PR TITLE
Fix - add user modal and domain table

### DIFF
--- a/components/icon/RoundedIcon.js
+++ b/components/icon/RoundedIcon.js
@@ -10,7 +10,7 @@ const TYPES = {
     error: 'bg-global-warning'
 };
 
-const RoundedIcon = ({ className = 'inline-flex rounded50', type = 'success', padding = 'p0-25', ...rest }) => {
+const RoundedIcon = ({ className = 'inline-flex rounded50 flex-item-noshrink', type = 'success', padding = 'p0-25', ...rest }) => {
     return (
         <span className={classnames([className, padding, TYPES[type]])}>
             <Icon {...rest} />

--- a/containers/domains/DomainName.js
+++ b/containers/domains/DomainName.js
@@ -13,14 +13,12 @@ const DomainName = ({ domain }) => {
     };
 
     return (
-        <>
-            <span className="flex flex-nowrap">
-                {ICONS[domain.State]}
-                <span className="ellipsis ml0-5" title={domain.DomainName}>
-                    {domain.DomainName}
-                </span>
+        <span className="flex flex-nowrap">
+            {ICONS[domain.State]}
+            <span className="ellipsis ml0-5" title={domain.DomainName}>
+                {domain.DomainName}
             </span>
-        </>
+        </span>
     );
 };
 

--- a/containers/domains/DomainName.js
+++ b/containers/domains/DomainName.js
@@ -14,7 +14,12 @@ const DomainName = ({ domain }) => {
 
     return (
         <>
-            {ICONS[domain.State]} {domain.DomainName}
+            <span className="flex flex-nowrap">
+                {ICONS[domain.State]}
+                <span className="ellipsis ml0-5" title={domain.DomainName}>
+                    {domain.DomainName}
+                </span>
+            </span>
         </>
     );
 };

--- a/containers/keys/addKey/SelectEncryption.js
+++ b/containers/keys/addKey/SelectEncryption.js
@@ -33,7 +33,7 @@ const SelectEncryption = ({ encryptionType, setEncryptionType }) => {
                 return (
                     <Row key={i}>
                         <Radio id={id} checked={value === encryptionType} onChange={() => setEncryptionType(value)}>
-                            <span>{label}</span>
+                            <span className="flex-item-fluid">{label}</span>
                         </Radio>
                     </Row>
                 );

--- a/containers/members/MemberModal.js
+++ b/containers/members/MemberModal.js
@@ -150,7 +150,7 @@ const MemberModal = ({ onClose, organization, organizationKey, domains, domainsA
                         required
                     />
                 </Field>
-                <div className="ml1">
+                <div className="ml1 onmobile-ml0">
                     <Checkbox checked={model.private} onChange={handleChangePrivate}>{c('Label for new member')
                         .t`Private`}</Checkbox>
                 </div>
@@ -194,9 +194,11 @@ const MemberModal = ({ onClose, organization, organizationKey, domains, domainsA
                         required
                     />
                 </Field>
-                <div className="ml1 flex flex-nowrap flex-items-center">
+                <div className="ml1 onmobile-ml0 flex flex-nowrap flex-items-center">
                     {domainOptions.length === 1 ? (
-                        `@${domainOptions[0].value}`
+                        <span className="ellipsis" title={`@${domainOptions[0].value}`}>
+                            @{domainOptions[0].value}
+                        </span>
                     ) : (
                         <Select options={domainOptions} value={model.domain} onChange={handleChange('domain')} />
                     )}


### PR DESCRIPTION
## Short description of what this resolves:

Some display bugs in italian.
https://user-images.githubusercontent.com/40168570/71166265-9d4db680-2252-11ea-8292-814236c44b7b.png

Also bonus: some bugs with long domain names in domain table.


## Changes proposed in this pull request:

- made radio + text not wrapping
- added ellipsis
- remove some margin for mobile proper display

Fixes: https://github.com/ProtonMail/proton-mail-settings/issues/278 


## Snapshot


![image](https://user-images.githubusercontent.com/2578321/72449117-71254700-37b8-11ea-8ccf-4b3f93eba4e5.png)

![image](https://user-images.githubusercontent.com/2578321/72449151-797d8200-37b8-11ea-8f76-ce8093d746bd.png)
