### PR TITLE
Fix toolbar link types

### DIFF
--- a/components/toolbar/ToolbarLink.tsx
+++ b/components/toolbar/ToolbarLink.tsx
@@ -1,16 +1,15 @@
-import React, { HTMLAttributes } from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
 import { classnames } from '../../helpers/component';
 import Icon, { Props as IconProps } from '../icon/Icon';
 
-interface Props extends HTMLAttributes<HTMLButtonElement> {
-    to: string;
+interface Props<S> extends LinkProps<S> {
     icon: string | IconProps;
 }
 
-const ToolbarLink = ({ to, icon, className, ...rest }: Props) => {
+function ToolbarLink<S>({ icon, className, ...rest }: Props<S>) {
     return (
-        <Link to={to} className={classnames([className, 'toolbar-button'])} {...rest}>
+        <Link className={classnames([className, 'toolbar-button'])} {...rest}>
             {typeof icon === 'string' ? (
                 <Icon name={icon} className="toolbar-icon mauto" />
             ) : (
@@ -18,6 +17,6 @@ const ToolbarLink = ({ to, icon, className, ...rest }: Props) => {
             )}
         </Link>
     );
-};
+}
 
 export default ToolbarLink;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@types/codemirror": "0.0.76",
     "@types/moment-timezone": "^0.5.12",
+    "@types/react-router-dom": "^5.1.3",
     "awesomplete": "^1.1.4",
     "card-validator": "^6.1.0",
     "codemirror": "^5.46.0",


### PR DESCRIPTION
Using from other projects that have @types/react-router-dom fails builds, because reacto-components didn't have them and ToolbarLink component's typing error was not visible.

## Short description of what this resolves:

I guess this error was hidden because of allowing typescript typecheck js files recursively in tsconfig, however that's necessary until more (all?) of the projects are using typescript.

## Changes proposed in this pull request:

Import types to see the error in react-components
Fix the wrong types, should've been LinkProps not HtmlProps

Fixes #

## Snapshot
