### PR TITLE
Make small modals have a shorter label width

### DIFF
--- a/components/modal/Dialog.js
+++ b/components/modal/Dialog.js
@@ -41,6 +41,7 @@ const Dialog = ({
                     className={classnames([
                         CLASSES.MODAL,
                         isSmall && CLASSES.MODAL_SMALL,
+                        isSmall && 'pm-modal--shorterLabels',
                         isClosing && CLASSES.MODAL_OUT,
                         extraClassNames
                     ])}


### PR DESCRIPTION
Forms in small modal look like this right now:

![Screenshot 2020-01-17 at 10 19 38](https://user-images.githubusercontent.com/352607/72601768-549f2100-3916-11ea-8c9d-039c30ce7706.png)

Add the shorter label modifier to those modals:

![Screenshot 2020-01-17 at 10 39 59](https://user-images.githubusercontent.com/352607/72601781-5a950200-3916-11ea-91c6-d05060343345.png)