### PR TITLE
Lazy load css for quill

### DIFF
--- a/components/input/LazyRichTextEditor.js
+++ b/components/input/LazyRichTextEditor.js
@@ -1,0 +1,16 @@
+import React, { lazy, Suspense } from 'react';
+import { Loader } from 'react-components';
+
+// lazy load RichTextEditor component to avoid loading unnecessary css styles
+const LazyRichTextEditor = lazy(() => import('./RichTextEditor'));
+
+// we need to suspend, otherwise the app will crash while loading
+const SuspendedLazyRichTextEditor = (props) => {
+    return (
+        <Suspense fallback={<Loader />}>
+            <LazyRichTextEditor {...props} />
+        </Suspense>
+    );
+};
+
+export default SuspendedLazyRichTextEditor;

--- a/components/input/RichTextEditor.js
+++ b/components/input/RichTextEditor.js
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactQuill from 'react-quill';
 import Quill from 'quill';
 
+// This style will be lazy loaded by LazyRichTextEditor
+import 'react-quill/dist/quill.snow.css';
+
 const Block = Quill.import('blots/block');
 Block.tagName = 'div';
 Quill.register(Block);

--- a/containers/autoReply/AutoReplyModal.js
+++ b/containers/autoReply/AutoReplyModal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormModal, useEventManager, useNotifications, useApi, useLoading } from 'react-components';
+import { FormModal, useEventManager, useNotifications, useApi, useLoading, RichTextEditor } from 'react-components';
 import { updateAutoresponder } from 'proton-shared/lib/api/mailSettings';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
@@ -12,7 +12,6 @@ import AutoReplyFormDaily from './AutoReplyForm/AutoReplyFormDaily';
 import AutoReplyFormWeekly from './AutoReplyForm/AutoReplyFormWeekly';
 import AutoReplyFormPermanent from './AutoReplyForm/AutoReplyFormPermanent';
 import DurationField from './AutoReplyForm/fields/DurationField';
-import RichTextEditor from '../../components/input/RichTextEditor';
 
 const AutoReplyModal = ({ onClose, autoresponder, ...rest }) => {
     const [loading, withLoading] = useLoading();

--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,7 @@ export { default as SimpleDropdown } from './components/dropdown/SimpleDropdown'
 export { usePopper, Popper, usePopperAnchor } from './components/popper';
 export { default as ColorSelector } from './components/color/ColorSelector';
 export { default as TimeInput } from './components/input/TimeInput';
-export { default as RichTextEditor } from './components/input/RichTextEditor';
+export { default as RichTextEditor } from './components/input/LazyRichTextEditor';
 export { default as Checkbox } from './components/input/Checkbox';
 export { default as ColorPicker } from './components/input/ColorPicker';
 export { default as useInput } from './components/input/useInput';

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,9 +1,5 @@
 $path-images: '~design-system/assets/img/shared/';
 
-@import '~react-quill/dist/quill.core.css';
-@import '~react-quill/dist/quill.bubble.css';
-@import '~react-quill/dist/quill.snow.css';
-
 @import '~awesomplete/awesomplete.css';
 
 @import '~design-system/_sass/reusable-components/design-system-config';


### PR DESCRIPTION
The CSS for the quill editor was like 1/4 of our total css. It does not make sense to load it when loading the app, but rather "on demand" (i.e. when some component needs to use it)