### PR TITLE
Fix - username not wrapped in member table

### DIFF
--- a/containers/members/MembersSection.js
+++ b/containers/members/MembersSection.js
@@ -159,7 +159,7 @@ const MembersSection = () => {
                             <TableRow
                                 key={key}
                                 cells={[
-                                    <span className="ellipsis mw100 inbl" title={member.Name}>{member.Name}</span>,
+                                    <span className="ellipsis mw100 inbl" key={key} title={member.Name}>{member.Name}</span>,
                                     <MemberRole key={key} member={member} />,
                                     <MemberPrivate key={key} member={member} />,
                                     <MemberAddresses key={key} member={member} addresses={memberAddresses} />,

--- a/containers/members/MembersSection.js
+++ b/containers/members/MembersSection.js
@@ -159,7 +159,7 @@ const MembersSection = () => {
                             <TableRow
                                 key={key}
                                 cells={[
-                                    member.Name,
+                                    <span className="ellipsis mw100 inbl" title={member.Name}>{member.Name}</span>,
                                     <MemberRole key={key} member={member} />,
                                     <MemberPrivate key={key} member={member} />,
                                     <MemberAddresses key={key} member={member} addresses={memberAddresses} />,


### PR DESCRIPTION
## Short description of what this resolves:

Long name in member table were not properly truncated.

## Changes proposed in this pull request:

- added ellipsis


## Snapshot

![image](https://user-images.githubusercontent.com/2578321/72730447-b28b6d00-3b91-11ea-8d0c-7f582b67c4ff.png)

