### PR TITLE
Fix - autocomplete dark mode friendly

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -47,7 +47,7 @@ const Autocomplete = ({
 
     const childrenCount = React.Children.count(children);
     const inputStyleModifier = childrenCount > 0 ? 'pm-field--tiny' : '';
-    const dropdownListClasses = 'bg-white w100 bordered-container m0 p0';
+    const dropdownListClasses = 'bg-white-dm w100 bordered-container m0 p0';
 
     useEffect(() => {
         const awesompleteInstance = new Awesomplete(inputRef.current, {

--- a/components/autocomplete/Autocomplete.scss
+++ b/components/autocomplete/Autocomplete.scss
@@ -1,6 +1,9 @@
+@import "~design-system/_sass/reusable-components/design-system-config";
+
 .autocomplete-input {
     flex: 1 0 15%;
     outline: none;
+    color: var(--color-input, $pm-global-grey);
 }
 
 .autocomplete-field {


### PR DESCRIPTION
## Short description of what this resolves:

Autocomplete in filters was not dark-mode friendly.
![image](https://user-images.githubusercontent.com/2578321/72811978-fdc08100-3c60-11ea-8582-f91b322e63f8.png)


## Changes proposed in this pull request:

Made dark-mode and autocomplete speak together, and they become friends:
- used a dark-mode-friendly helper
- added a fix for text color in autocomplete input
 
## Snapshot

![image](https://user-images.githubusercontent.com/2578321/72811909-dd90c200-3c60-11ea-9770-5a80d0aea941.png)

