### PR TITLE
Allow link NavItem to also add onClick handler

### DIFF
--- a/components/sidebar/NavItem.js
+++ b/components/sidebar/NavItem.js
@@ -44,6 +44,7 @@ const NavItem = ({
                     isActive={isActive}
                     to={link}
                     aria-current={ariaCurrent}
+                    onClick={onClick}
                 >
                     {content}
                 </NavLink>


### PR DESCRIPTION
I understand it could feal strange but in mail, menu items are links, still, if you click on the active one, I need to trigger a manual refresh so I would really need to have both link and onClick features.

Using button type in this case could work but it is semanticaly bad and it breaks the aria-current style.