### PR TITLE
Feat - url for dark version of placeholder images

### DIFF
--- a/containers/illustration/IllustrationPlaceholder.js
+++ b/containers/illustration/IllustrationPlaceholder.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { classnames } from '../../helpers/component';
 
-const IllustrationPlaceholder = ({ className, title, text, url, uppercase, children }) => {
+const IllustrationPlaceholder = ({ className, title, text, url, urlDarkVersion = '', uppercase, children }) => {
     const info = typeof text === 'string' ? <p>{text}</p> : text;
+    const darkImg = urlDarkVersion !== '' ? <img src={urlDarkVersion} alt={title} className="p1 mb1 display-on-darkmode" /> : null;
 
     return (
         <div className={classnames(['flex flex-column flex-items-center w100', className])}>
-            <img src={url} alt={title} className="p1 mb1" />
+            <img src={url} alt={title} className={classnames(['p1 mb1', darkImg && 'hide-on-darkmode'])} />
+            {darkImg}
             <h2 className={classnames(['bold', uppercase && 'uppercase'])}>{title}</h2>
             {info}
             {children}
@@ -20,6 +22,7 @@ IllustrationPlaceholder.propTypes = {
     title: PropTypes.string.isRequired,
     text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     url: PropTypes.string.isRequired,
+    urlDarkVersion: PropTypes.string,
     uppercase: PropTypes.bool,
     children: PropTypes.node
 };


### PR DESCRIPTION
## Short description of what this resolves:

Missing support of dark mode version for placeholder illustrations.

## Changes proposed in this pull request:

- added `urlDarkVersion` property (not mandatory, in some cases, the image could fit in both cases ^^) 
- if specified, will be displayed
- added a class `hide-on-darkmode` in case of dark version (to hide the "light" version)

## Snapshot

![image](https://user-images.githubusercontent.com/2578321/73075010-2f348900-3ebb-11ea-8437-6431cb7db126.png)
