### PR TITLE
Fix - revamp Loader (inline SVG)

### DIFF
--- a/components/loader/Loader.tsx
+++ b/components/loader/Loader.tsx
@@ -1,31 +1,62 @@
 import React from 'react';
 import { c } from 'ttag';
-import loadingSvg from 'design-system/assets/img/shared/loading-atom.svg';
-import loadingSmallerSvg from 'design-system/assets/img/shared/loading-atom-smaller.svg';
+import { classnames } from '../../helpers/component';
 
-const IMAGES = {
-    small: loadingSmallerSvg,
-    medium: loadingSvg,
-    big: loadingSvg
+const WIDTH = {
+    small: '20',
+    medium: '80',
+    big: '200'
 };
 
-const MEDIUM_WIDTH = '80';
-const MEDIUM_HEIGHT = '80';
+const CLASSES_ORBIT1 = {
+    small: 'loadingAnimation-circle--smaller loadingAnimation-orbit1--smaller',
+    medium: 'loadingAnimation-orbit1',
+    big: 'loadingAnimation-orbit1'
+};
+const CLASSES_ORBIT2 = {
+    small: 'loadingAnimation-circle--smaller loadingAnimation-orbit2--smaller',
+    medium: 'loadingAnimation-orbit2',
+    big: 'loadingAnimation-orbit2'
+};
+
+
 
 interface Props {
     size?: 'small' | 'medium' | 'big';
+    bgColor?: string;
 }
 
-const Loader = ({ size = 'small' }: Props) => {
+
+const Loader = ({ size = 'small', bgColor = '' }: Props) => {
+    const diameter = size !== 'small' ? '100' : '10';
+    const radius = size !== 'small' ? '80' : '8';
+
+    const classNameOrbit = [ 'loadingAnimation-circle ', bgColor === 'primary' && 'loadingAnimation-circle--pm-primary' ];
+    const classNameOrbit1 = classnames([ ...classNameOrbit, CLASSES_ORBIT1[size] ]);
+    const classNameOrbit2 = classnames([ ...classNameOrbit, CLASSES_ORBIT2[size] ]);
+
     return (
         <div className="center flex mb2 mt2">
-            <img
-                className="mauto"
-                src={IMAGES[size]}
-                width={size === 'medium' ? MEDIUM_WIDTH : undefined}
-                height={size === 'medium' ? MEDIUM_HEIGHT : undefined}
-                alt={c('Info').t`Loading`}
-            />
+            <svg xmlns="http://www.w3.org/2000/svg"
+                className="loadingAnimation mauto"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+                viewBox={ size !== 'small' ? '0 0 200 200' : '0 0 20 20' }
+                width={WIDTH[size]}
+                height={WIDTH[size]}>
+                <circle
+                    cx={diameter}
+                    cy={diameter}
+                    r={radius}
+                    className={classNameOrbit1} />
+                <circle
+                    cx={diameter}
+                    cy={diameter}
+                    r={radius}
+                    className={classNameOrbit2} />
+            </svg>
+            <span className="sr-only">{c('Info').t`Loading`}</span>
         </div>
     );
 };


### PR DESCRIPTION
## Short description of what this resolves:

I needed to have a loader that could have primary color, in order to have export contacts loader in primary color (which is dark mode compatible), and probably other loaders to come for other projects.

## Changes proposed in this pull request:

- inlined SVG for loading animation (this is lighter!)
- added option `bgColor` in order to style with primary color of project (good for VPN), by default, it will be black (and white in dark mode)
- sizes and design remains the same as actually

## Snapshot

Example in contacts: `<Loader bgColor="primary" size="medium" />`
![image](https://user-images.githubusercontent.com/2578321/73088729-13d67780-3ed5-11ea-8741-ed45d420716e.png)

