### PR TITLE
Allow Dropdown props autoCloseOutside to change during components life

### DIFF
--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -64,7 +64,7 @@ const Dropdown = ({
             document.removeEventListener('touchstart', handleClickOutside);
             document.removeEventListener('keydown', handleKeydown);
         };
-    }, []);
+    }, [autoCloseOutside]);
 
     const contentClassName = classnames([
         'dropDown',


### PR DESCRIPTION
Inspired by the Angular code (https://github.com/ProtonMail/Angular/blob/v4/src/app/labels/directives/dropdownLabels.js#L58), I need to lock opened my dropdown while opening a modal on top of it.

It's almost possible with the existing `autoCloseOutside` props but it needs this fix to manage the value to change in time.