### PR TITLE
Fix - custom scroll bar in navigation

### DIFF
--- a/components/sidebar/Sidebar.js
+++ b/components/sidebar/Sidebar.js
@@ -17,7 +17,7 @@ const Sidebar = ({ expanded = false, onToggleExpand, list = [], url = '', mobile
                 </div>
             </div>
             {children}
-            <nav className="navigation mw100 flex-item-fluid scroll-if-needed mb1">
+            <nav className="navigation mw100 flex-item-fluid scroll-if-needed customScrollBar-container mb1">
                 <NavMenu list={list} />
             </nav>
             {mobileLinks.length ? (


### PR DESCRIPTION
## Short description of what this resolves:

Allow the scrolling to be done on the full height of the menu.

## Changes proposed in this pull request:

- added custom scrollbar class on navigation container (for subfolder and dark mode and etc.)


## Snapshot

![image](https://user-images.githubusercontent.com/2578321/73360051-68e20700-42a2-11ea-8042-1f04dcede940.png)

