### PR TITLE
Fix - storage popover margins

### DIFF
--- a/containers/sidebar/StorageSpaceStatus.js
+++ b/containers/sidebar/StorageSpaceStatus.js
@@ -57,9 +57,10 @@ const StorageSpaceStatus = ({ upgradeButton }) => {
                 size="auto"
             >
                 <div className="dropDown-content">
-                    <div className="absolute top-right mt0-5 mr0-5">
-                        <button className="flex flex-items-center">
+                    <div className="absolute top-right mt0-5r mr0-5r">
+                        <button className="flex flex-items-center" title={c('Action').t`Close`}>
                             <Icon name="close" />
+                            <span className="sr-only">{c('Action').t`Close`}</span>
                         </button>
                     </div>
                     <div className="flex p1">


### PR DESCRIPTION
## Short description of what this resolves:

The margin on Close button on storage popover was not the same as for other popovers/modals

## Changes proposed in this pull request:

- set it up to exact same values as for modals/popovers
- bonus, added a text for better a11y  (empty buttons are badly vocalized)

## Snapshot

![image](https://user-images.githubusercontent.com/2578321/73441726-ba969a00-4353-11ea-9408-ca119de3f7d2.png)
